### PR TITLE
Fix missing inheritance for resque collector

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@ Changelog for the bc-prometheus-ruby gem.
 
 ### Pending Release
 
+- Fix missing inheritance for resque collector
+ 
 ### 0.2.1
 
 - Prevent starting of Puma integration if Puma is not loaded

--- a/lib/bigcommerce/prometheus/collectors/resque.rb
+++ b/lib/bigcommerce/prometheus/collectors/resque.rb
@@ -21,7 +21,7 @@ module Bigcommerce
       ##
       # Collect metrics to push to the server type collector
       #
-      class Resque
+      class Resque < Base
         ##
         # @param [Hash] metrics
         # @return [Hash]


### PR DESCRIPTION
The resque collector is not inheriting from base, which causes a missing `start` method error.

----

@bigcommerce/ruby @bigcommerce/platform-engineering @ncheikh 