### PR TITLE
Fix cant modify frozen array error when using bc-prometheus-ruby outside a web process

### DIFF
--- a/lib/bigcommerce/prometheus/instrumentors/web.rb
+++ b/lib/bigcommerce/prometheus/instrumentors/web.rb
@@ -84,6 +84,8 @@ module Bigcommerce
 
         def setup_middleware
           @app.middleware.unshift(PrometheusExporter::Middleware, client: Bigcommerce::Prometheus.client)
+        rescue StandardError => e
+          logger.warn "[bc-prometheus-ruby] Failed to attach app middleware in web instrumentor: #{e.message}"
         end
       end
     end

--- a/lib/bigcommerce/prometheus/integrations/railtie.rb
+++ b/lib/bigcommerce/prometheus/integrations/railtie.rb
@@ -22,7 +22,7 @@ module Bigcommerce
       # Railtie for automatic configuration of Rails environments
       #
       class Railtie < ::Rails::Railtie
-        config.after_initialize do |app|
+        initializer 'zzz.bc_prometheus_ruby.configure_rails_initialization' do |app|
           Bigcommerce::Prometheus::Instrumentors::Web.new(app: app).start
         end
       end


### PR DESCRIPTION
## What?

Fixes:

```[bc-prometheus-ruby] Failed to attach app middleware in web instrumentor: can't modify frozen Array```

When using bc-prometheus-ruby within Rails, but in a non-web process. Also adds a guard to log a warning if it occurs, rather than bubbling up.

----

@bigcommerce/platform-engineering @jmwiese @bigcommerce/ruby 