### PR TITLE
Improve custom collector interfaces, consolidate configuration

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -30,3 +30,6 @@ Metrics/CyclomaticComplexity:
 
 Metrics/PerceivedComplexity:
   Max: 30
+
+Metrics/ParameterLists:
+  Enabled: false

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@ Changelog for the bc-prometheus-ruby gem.
 
 ### Pending Release
 
+- Add ability to pass custom resque and hutch Collectors/TypeCollectors
+- Add ENV support for all configuration elements
+- Fix issue where base collector did not use Bigcommerce::Prometheus.client
+- Expose new `push` method for Collectors::Base to ease use of custom ad hoc metrics 
+
 ### 0.2.4
 
 - Fix cant modify frozen array error when using bc-prometheus-ruby outside a web process 

--- a/lib/bigcommerce/prometheus/client.rb
+++ b/lib/bigcommerce/prometheus/client.rb
@@ -24,16 +24,16 @@ module Bigcommerce
       include Singleton
       include Loggable
 
-      def initialize
+      def initialize(host: nil, port: nil, max_queue_size: nil, thread_sleep: nil, custom_labels: nil, process_name: nil)
         super(
-          host: Bigcommerce::Prometheus.server_host,
-          port: Bigcommerce::Prometheus.server_port,
-          max_queue_size: Bigcommerce::Prometheus.client_max_queue_size,
-          thread_sleep: Bigcommerce::Prometheus.client_thread_sleep,
-          custom_labels: Bigcommerce::Prometheus.client_custom_labels
+          host: host || Bigcommerce::Prometheus.server_host,
+          port: port || Bigcommerce::Prometheus.server_port,
+          max_queue_size: max_queue_size || Bigcommerce::Prometheus.client_max_queue_size,
+          thread_sleep: thread_sleep || Bigcommerce::Prometheus.client_thread_sleep,
+          custom_labels: custom_labels || Bigcommerce::Prometheus.client_custom_labels
         )
         PrometheusExporter::Client.default = self
-        @process_name = ::Bigcommerce::Prometheus.process_name
+        @process_name = process_name || ::Bigcommerce::Prometheus.process_name
       end
 
       ##
@@ -55,7 +55,7 @@ module Bigcommerce
 
       ##
       # @param [String] path
-      # @return [URI]
+      # @return [Module<URI>]
       #
       def uri_path(path)
         URI("http://#{@host}:#{@port}#{path}")

--- a/lib/bigcommerce/prometheus/configuration.rb
+++ b/lib/bigcommerce/prometheus/configuration.rb
@@ -23,18 +23,32 @@ module Bigcommerce
     module Configuration
       VALID_CONFIG_KEYS = {
         logger: nil,
+        enabled: ENV.fetch('PROMETHEUS_ENABLED', 1).to_i.positive?,
+
+        # Client configuration
         client_custom_labels: nil,
-        client_max_queue_size: 10_000,
-        client_thread_sleep: 0.5,
-        enabled: true,
-        puma_collection_frequency: 30,
-        puma_process_label: 'web',
-        resque_collection_frequency: 30,
-        resque_process_label: 'resque',
-        server_host: '0.0.0.0',
-        server_port: PrometheusExporter::DEFAULT_PORT,
-        server_timeout: PrometheusExporter::DEFAULT_TIMEOUT,
-        server_prefix: PrometheusExporter::DEFAULT_PREFIX,
+        client_max_queue_size: ENV.fetch('PROMETHEUS_CLIENT_MAX_QUEUE_SIZE', 10_000).to_i,
+        client_thread_sleep: ENV.fetch('PROMETHEUS_CLIENT_THREAD_SLEEP', 0.5).to_f,
+
+        # Integration configuration
+        puma_collection_frequency: ENV.fetch('PROMETHEUS_PUMA_COLLECTION_FREQUENCY', 30).to_i,
+        puma_process_label: ENV.fetch('PROMETHEUS_PUMA_PROCESS_LABEL', 'web').to_s,
+        resque_collection_frequency: ENV.fetch('PROMETHEUS_RESQUE_COLLECTION_FREQUENCY', 30).to_i,
+        resque_process_label: ENV.fetch('PROMETHEUS_REQUEST_PROCESS_LABEL', 'resque').to_s,
+
+        # Server configuration
+        not_found_body: ENV.fetch('PROMETHEUS_SERVER_NOT_FOUND_BODY', 'Not Found! The Prometheus Ruby Exporter only listens on /metrics and /send-metrics').to_s,
+        server_host: ENV.fetch('PROMETHEUS_SERVER_HOST', '0.0.0.0').to_s,
+        server_port: ENV.fetch('PROMETHEUS_SERVER_PORT', PrometheusExporter::DEFAULT_PORT).to_i,
+        server_timeout: ENV.fetch('PROMETHEUS_DEFAULT_TIMEOUT', PrometheusExporter::DEFAULT_TIMEOUT).to_i,
+        server_prefix: ENV.fetch('PROMETHEUS_DEFAULT_PREFIX', PrometheusExporter::DEFAULT_PREFIX).to_s,
+
+        # Custom collector configuration
+        collector_collection_frequency: ENV.fetch('PROMETHEUS_DEFAULT_COLLECTOR_COLLECTION_FREQUENCY_SEC', 15).to_i,
+        hutch_collectors: [],
+        hutch_type_collectors: [],
+        resque_collectors: [],
+        resque_type_collectors: [],
         web_collectors: [],
         web_type_collectors: []
       }.freeze
@@ -85,12 +99,7 @@ module Bigcommerce
           send("#{k}=".to_sym, v)
         end
         determine_logger
-        self.enabled = ENV.fetch('PROMETHEUS_ENABLED', 1).to_i.positive?
-        self.server_host = ENV.fetch('PROMETHEUS_SERVER_HOST', '0.0.0.0').to_s
-        self.server_port = ENV.fetch('PROMETHEUS_SERVER_PORT', PrometheusExporter::DEFAULT_PORT).to_i
 
-        self.puma_process_label = ENV.fetch('PROMETHEUS_PUMA_PROCESS_LABEL', 'web').to_s
-        self.puma_collection_frequency = ENV.fetch('PROMETHEUS_PUMA_COLLECTION_FREQUENCY', 30).to_i
         self.web_type_collectors = []
       end
 

--- a/lib/bigcommerce/prometheus/instrumentors/web.rb
+++ b/lib/bigcommerce/prometheus/instrumentors/web.rb
@@ -77,7 +77,7 @@ module Bigcommerce
         def setup_after_fork
           @app.config.after_fork_callbacks = [] unless @app.config.after_fork_callbacks
           @app.config.after_fork_callbacks << lambda do
-            ::Bigcommerce::Prometheus::Integrations::Puma.start
+            ::Bigcommerce::Prometheus::Integrations::Puma.start(client: Bigcommerce::Prometheus.client)
             @collectors.each(&:start)
           end
         end

--- a/lib/bigcommerce/prometheus/integrations/resque.rb
+++ b/lib/bigcommerce/prometheus/integrations/resque.rb
@@ -25,13 +25,13 @@ module Bigcommerce
         ##
         # Start the resque integration
         #
-        def self.start
+        def self.start(client: nil)
           ::PrometheusExporter::Instrumentation::Process.start(
-            client: ::Bigcommerce::Prometheus.client,
+            client: client || ::Bigcommerce::Prometheus.client,
             type: ::Bigcommerce::Prometheus.resque_process_label
           )
           ::Bigcommerce::Prometheus::Collectors::Resque.start(
-            client: ::Bigcommerce::Prometheus.client,
+            client: client || ::Bigcommerce::Prometheus.client,
             frequency: ::Bigcommerce::Prometheus.resque_collection_frequency
           )
         end

--- a/lib/bigcommerce/prometheus/servers/thin/controllers/not_found_controller.rb
+++ b/lib/bigcommerce/prometheus/servers/thin/controllers/not_found_controller.rb
@@ -26,7 +26,7 @@ module Bigcommerce
           class NotFoundController < BaseController
             def call
               @response.status = 404
-              @response.body << 'Not Found! The Prometheus Ruby Exporter only listens on /metrics and /send-metrics'
+              @response.body << Bigcommerce::Prometheus.not_found_body
             end
           end
         end

--- a/lib/bigcommerce/prometheus/servers/thin/server.rb
+++ b/lib/bigcommerce/prometheus/servers/thin/server.rb
@@ -24,9 +24,9 @@ module Bigcommerce
         #
         class Server < ::Thin::Server
           def initialize(port:, host: nil, timeout: nil, logger: nil)
-            @port = port || ::PrometheusExporter::DEFAULT_PORT
-            @host = host || '0.0.0.0'
-            @timeout = timeout || ::PrometheusExporter::DEFAULT_TIMEOUT
+            @port = port || ::Bigcommerce::Prometheus.server_port
+            @host = host || ::Bigcommerce::Prometheus.server_host
+            @timeout = timeout || ::Bigcommerce::Prometheus.server_timeout
             @logger = logger || ::Bigcommerce::Prometheus.logger
             @rack_app = ::Bigcommerce::Prometheus::Servers::Thin::RackApp.new(timeout: timeout, logger: logger)
             super(@host, @port, @rack_app)

--- a/spec/bigcommerce/prometheus/collectors/base_spec.rb
+++ b/spec/bigcommerce/prometheus/collectors/base_spec.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-# Copyright (c) 2019-present, BigCommerce Pty. Ltd. All rights reserved
+# Copyright (c) 2020-present, BigCommerce Pty. Ltd. All rights reserved
 #
 # Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated
 # documentation files (the "Software"), to deal in the Software without restriction, including without limitation the
@@ -15,8 +15,37 @@
 # COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR
 # OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 #
-module Bigcommerce
-  module Prometheus
-    VERSION = '0.3.0.pre'
+
+require 'spec_helper'
+
+describe Bigcommerce::Prometheus::Collectors::Base do
+  let(:client) { double(:client, send_json: true) }
+  let(:collector) { Test::DynamicCollector.new(client: client, frequency: 0) }
+
+  describe '.run' do
+    subject { collector.run }
+
+    it 'should collect and push the metrics, then sleep the frequency' do
+      expect(client).to receive(:send_json).with(
+        type: 'test_dynamic',
+        bonks: 42
+      ).once
+      subject
+    end
+  end
+
+  describe '.add_widget' do
+    subject { collector.add_widget }
+
+    it 'should push the metric dynamically' do
+      expect(client).to receive(:send_json).with(
+        type: 'test_dynamic',
+        widgets: 1,
+        custom_labels: {
+          shape: 'round'
+        }
+      ).once
+      subject
+    end
   end
 end

--- a/spec/demo/server
+++ b/spec/demo/server
@@ -45,4 +45,11 @@ server.start_until_stopped do
   sleep 2
   ::Bigcommerce::Prometheus::Integrations::Puma.start
   Demo::GeeseCollector.start
+
+  collector = Demo::GeeseCollector.new
+  loop do
+    collector.honk # ad hoc metric
+    logger.info 'HONK!'
+    sleep 3
+  end
 end

--- a/spec/demo/support.rb
+++ b/spec/demo/support.rb
@@ -34,17 +34,25 @@ module Demo
   class GeeseTypeCollector < Bigcommerce::Prometheus::TypeCollectors::Base
     def build_metrics
       {
-        geese_total: PrometheusExporter::Metric::Gauge.new('geese_total', 'Number of geese')
+        geese_total: PrometheusExporter::Metric::Gauge.new('geese_total', 'Number of geese'),
+        honks: PrometheusExporter::Metric::Counter.new('honks', 'Number of honks')
       }
     end
 
     def collect_metrics(data:, labels: {})
       metric(:geese_total)&.observe(data['geese_total'], labels)
+      metric(:honks).observe(1, labels) if data.fetch('honks', 0).to_i.positive?
     end
   end
 
   # Custom collector
   class GeeseCollector < Bigcommerce::Prometheus::Collectors::Base
+    def honk
+      push(
+        honks: 1
+      )
+    end
+
     def collect(metrics)
       metrics[:geese_total] = rand(100)
       metrics


### PR DESCRIPTION
## What?

- Adds ability to pass custom resque and hutch Collectors/TypeCollectors
- Adds ENV support for all configuration elements
- Fixes issue where base collector did not use Bigcommerce::Prometheus.client
- Exposes new `push` method for Collectors::Base to ease use of custom ad hoc metrics 

README updates will come in the next PR (along with better documentation on how to write custom collectors/type-collectors).

----

@bigcommerce/ruby @bigcommerce/platform-engineering @jmwiese @pedelman 