### PR TITLE
Deprecate pre-Ruby-2.6 support; update README

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -13,24 +13,12 @@ ruby_env: &ruby_env
     - image: circleci/ruby:<<parameters.ruby-version>>
 
 executors:
-  ruby_2_4:
-    <<: *ruby_env
-    parameters:
-      ruby-version:
-        type: string
-        default: "2.4.6"
-  ruby_2_5:
-    <<: *ruby_env
-    parameters:
-      ruby-version:
-        type: string
-        default: "2.5.5"
   ruby_2_6:
     <<: *ruby_env
     parameters:
       ruby-version:
         type: string
-        default: "2.6.3"
+        default: "2.6.6"
 
 commands:
   pre-setup:
@@ -86,7 +74,7 @@ jobs:
     parameters:
       e:
         type: executor
-        default: "ruby_2_4"
+        default: "ruby_2_6"
     steps:
       - pre-setup
       - bundle-install
@@ -96,7 +84,7 @@ jobs:
     parameters:
       e:
         type: executor
-        default: "ruby_2_4"
+        default: "ruby_2_6"
     steps:
       - pre-setup
       - bundle-install
@@ -106,7 +94,7 @@ jobs:
     parameters:
       e:
         type: executor
-        default: "ruby_2_4"
+        default: "ruby_2_6"
     steps:
       - pre-setup
       - bundle-install
@@ -114,25 +102,6 @@ jobs:
 
 workflows:
   version: 2
-  ruby_2_4:
-    jobs:
-      - bundle-audit:
-          name: "ruby-2_4-bundle_audit"
-      - rubocop:
-          name: "ruby-2_4-rubocop"
-      - rspec-unit:
-          name: "ruby-2_4-rspec"
-  ruby_2_5:
-    jobs:
-      - bundle-audit:
-          name: "ruby-2_5-bundle_audit"
-          e: "ruby_2_5"
-      - rubocop:
-          name: "ruby-2_5-rubocop"
-          e: "ruby_2_5"
-      - rspec-unit:
-          name: "ruby-2_5-rspec"
-          e: "ruby_2_5"
   ruby_2_6:
     jobs:
       - bundle-audit:

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,5 +1,5 @@
 AllCops:
-  TargetRubyVersion: 2.4
+  TargetRubyVersion: 2.6
   Exclude:
     - spec/**/*
     - .bundle/**/*

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@ Changelog for the bc-prometheus-ruby gem.
 
 ### Pending Release
 
+- Support for only Ruby 2.6+ going forward
+- Updated README around custom metrics and collectors
 - Add ability to pass custom resque and hutch Collectors/TypeCollectors
 - Add ENV support for all configuration elements
 - Fix issue where base collector did not use Bigcommerce::Prometheus.client

--- a/bc-prometheus-ruby.gemspec
+++ b/bc-prometheus-ruby.gemspec
@@ -31,6 +31,7 @@ Gem::Specification.new do |spec|
 
   spec.files         = Dir['README.md', 'CHANGELOG.md', 'CODE_OF_CONDUCT.md', 'lib/**/*', 'bc-prometheus-ruby.gemspec']
   spec.require_paths = ['lib']
+  spec.required_ruby_version = '>= 2.6'
 
   spec.add_development_dependency 'rake', '>= 10.0'
   spec.add_development_dependency 'rspec', '>= 3.8'

--- a/spec/bigcommerce/prometheus/collectors/base_spec.rb
+++ b/spec/bigcommerce/prometheus/collectors/base_spec.rb
@@ -20,29 +20,29 @@ require 'spec_helper'
 
 describe Bigcommerce::Prometheus::Collectors::Base do
   let(:client) { double(:client, send_json: true) }
-  let(:collector) { Test::DynamicCollector.new(client: client, frequency: 0) }
+  let(:collector) { AppCollector.new(client: client, frequency: 0) }
 
   describe '.run' do
     subject { collector.run }
 
     it 'should collect and push the metrics, then sleep the frequency' do
       expect(client).to receive(:send_json).with(
-        type: 'test_dynamic',
-        bonks: 42
+        type: 'app',
+        points: 42
       ).once
       subject
     end
   end
 
-  describe '.add_widget' do
-    subject { collector.add_widget }
+  describe '.honk!' do
+    subject { collector.honk! }
 
     it 'should push the metric dynamically' do
       expect(client).to receive(:send_json).with(
-        type: 'test_dynamic',
-        widgets: 1,
+        type: 'app',
+        honks: 1,
         custom_labels: {
-          shape: 'round'
+          volume: 'loud'
         }
       ).once
       subject

--- a/spec/demo/server
+++ b/spec/demo/server
@@ -20,7 +20,7 @@ ENV['PROCESS'] = 'demo'
 $LOAD_PATH.unshift File.expand_path('../../../lib', __FILE__)
 require 'bigcommerce/prometheus'
 require 'logger'
-require_relative 'support'
+require_relative '../support/collectors'
 
 logger = ::Logger.new(STDOUT)
 logger.level = ::Logger::Severity::INFO
@@ -30,25 +30,25 @@ logger.level = ::Logger::Severity::INFO
   c.server_host = '0.0.0.0'
   c.logger = logger
   c.puma_collection_frequency = 5
-  c.web_collectors = [Demo::GeeseCollector]
-  c.web_type_collectors = [Demo::GeeseTypeCollector.new]
+  c.web_collectors = [AppCollector]
+  c.web_type_collectors = [AppTypeCollector.new]
 end
 
 server = ::Bigcommerce::Prometheus::Server.new
+server.add_type_collector(PrometheusExporter::Server::ActiveRecordCollector.new)
+server.add_type_collector(PrometheusExporter::Server::WebCollector.new)
+server.add_type_collector(PrometheusExporter::Server::PumaCollector.new)
 Bigcommerce::Prometheus.web_type_collectors.each do |tc|
-  server.add_type_collector(PrometheusExporter::Server::ActiveRecordCollector.new)
-  server.add_type_collector(PrometheusExporter::Server::WebCollector.new)
-  server.add_type_collector(PrometheusExporter::Server::PumaCollector.new)
   server.add_type_collector(tc)
 end
 server.start_until_stopped do
   sleep 2
   ::Bigcommerce::Prometheus::Integrations::Puma.start
-  Demo::GeeseCollector.start
+  AppCollector.start
 
-  collector = Demo::GeeseCollector.new
+  collector = AppCollector.new
   loop do
-    collector.honk # ad hoc metric
+    collector.honk! # ad hoc metric
     logger.info 'HONK!'
     sleep 3
   end

--- a/spec/demo/support.rb
+++ b/spec/demo/support.rb
@@ -28,34 +28,3 @@ class Puma
     }.to_json
   end
 end
-
-# Custom type collector
-module Demo
-  class GeeseTypeCollector < Bigcommerce::Prometheus::TypeCollectors::Base
-    def build_metrics
-      {
-        geese_total: PrometheusExporter::Metric::Gauge.new('geese_total', 'Number of geese'),
-        honks: PrometheusExporter::Metric::Counter.new('honks', 'Number of honks')
-      }
-    end
-
-    def collect_metrics(data:, labels: {})
-      metric(:geese_total)&.observe(data['geese_total'], labels)
-      metric(:honks).observe(1, labels) if data.fetch('honks', 0).to_i.positive?
-    end
-  end
-
-  # Custom collector
-  class GeeseCollector < Bigcommerce::Prometheus::Collectors::Base
-    def honk
-      push(
-        honks: 1
-      )
-    end
-
-    def collect(metrics)
-      metrics[:geese_total] = rand(100)
-      metrics
-    end
-  end
-end

--- a/spec/support/collectors.rb
+++ b/spec/support/collectors.rb
@@ -17,34 +17,32 @@
 #
 # frozen_string_literal: true
 
-module Test
-  class DynamicCollector < ::Bigcommerce::Prometheus::Collectors::Base
-    def add_widget
-      push(
-        widgets: 1,
-        custom_labels: {
-          shape: 'round'
-        }
-      )
-    end
-
-    def collect(metrics)
-      metrics[:bonks] = 42
-      metrics
-    end
+class AppCollector < ::Bigcommerce::Prometheus::Collectors::Base
+  def honk!
+    push(
+      honks: 1,
+      custom_labels: {
+        volume: 'loud'
+      }
+    )
   end
 
-  class DynamicTypeCollector < ::Bigcommerce::Prometheus::TypeCollectors::Base
-    def build_metrics
-      {
-        bonks: PrometheusExporter::Metric::Counter.new('bonks', 'Running counter of bonks'),
-        widgets: PrometheusExporter::Metric::Gauge.new('widgets', 'Current amount of widgets')
-      }
-    end
+  def collect(metrics)
+    metrics[:points] = 42
+    metrics
+  end
+end
 
-    def collect_metrics(data:, labels: {})
-      metric(:widgets).observe(data.fetch('widgets', 0), labels)
-      metric(:bonks).observe(1, labels) if data.fetch('bonks', 0).to_i.positive?
-    end
+class AppTypeCollector < ::Bigcommerce::Prometheus::TypeCollectors::Base
+  def build_metrics
+    {
+      honks: PrometheusExporter::Metric::Counter.new('honks', 'Running counter of honks'),
+      points: PrometheusExporter::Metric::Gauge.new('points', 'Current amount of points')
+    }
+  end
+
+  def collect_metrics(data:, labels: {})
+    metric(:honks).observe(1, labels) if data.fetch('honks', 0).to_i.positive?
+    metric(:points).observe(data.fetch('points', 0), labels)
   end
 end


### PR DESCRIPTION
## What?

* Deprecates support for Ruby versions earlier than 2.6
* Updates README with information on setting up Custom Metrics
* Adjust the demo server to use the same type of custom collector as the README

----

@bigcommerce/ruby @bigcommerce/platform-engineering @jmwiese 