### PR TITLE
Bump prometheus-exporter to ~> 0.5 to address memory leak in 0.4.x

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@ Changelog for the bc-prometheus-ruby gem.
 
 ### Pending Release
 
+- Update prometheus_exporter dependency to ~> 0.5 to fix memory leaks
+
 ### 0.3.0
 
 - Support for only Ruby 2.6+ going forward

--- a/bc-prometheus-ruby.gemspec
+++ b/bc-prometheus-ruby.gemspec
@@ -43,6 +43,6 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency 'simplecov', '>= 0.16'
 
   spec.add_runtime_dependency 'bigcommerce-multitrap', '~> 0.1'
-  spec.add_runtime_dependency 'prometheus_exporter', '~> 0.4'
+  spec.add_runtime_dependency 'prometheus_exporter', '~> 0.5'
   spec.add_runtime_dependency 'thin', '~> 1.7'
 end

--- a/script/test
+++ b/script/test
@@ -1,0 +1,9 @@
+#!/usr/bin/env bash
+
+set -e
+
+bundle install
+bundle exec rubocop -P -c ./.rubocop.yml
+bundle exec bundle-audit update
+bundle exec bundle-audit check
+bundle exec rspec


### PR DESCRIPTION
## What?

Bumps prometheus_exporter dependency to `~> 0.5` to address memory leak in Puma collector in `~> 0.4`.

Also adds `./script/test` for easy full testing in dev.

----

@bigcommerce/platform-engineering @bigcommerce/ruby 