### PR TITLE
fix(bmp): brp-11905 use after_initialize

### DIFF
--- a/lib/bigcommerce/prometheus/integrations/railtie.rb
+++ b/lib/bigcommerce/prometheus/integrations/railtie.rb
@@ -22,7 +22,7 @@ module Bigcommerce
       # Railtie for automatic configuration of Rails environments
       #
       class Railtie < ::Rails::Railtie
-        initializer 'zzz.bc_prometheus_ruby.configure_rails_initialization' do |app|
+        config.after_initialize do |app|
           Bigcommerce::Prometheus::Instrumentors::Web.new(app: app).start
         end
       end


### PR DESCRIPTION
# The problem

We recently discovered a service was not reporting on our custom Prometheus metrics.

# Steps taken to resolve

Long and short, I went back through older versions of the service and found the commit where things stopped working.

# The solution

After investigation, reverting the `Railtie` initializer change resolved the problem 🎉 

This reverts a change introduced in `0.2.4`
- https://github.com/bigcommerce/bc-prometheus-ruby/releases/tag/v0.2.4
- https://github.com/bigcommerce/bc-prometheus-ruby/commit/36d827873a1a367d6bbbc2aa3525dbcf9932b4f7
