### PR TITLE
chore(platform): PAYMENTS-6381 Bumping prometheus_exporter gem to support Rails 6.1 upgrade

### DIFF
--- a/bc-prometheus-ruby.gemspec
+++ b/bc-prometheus-ruby.gemspec
@@ -43,6 +43,6 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency 'simplecov', '>= 0.16'
 
   spec.add_runtime_dependency 'bigcommerce-multitrap', '~> 0.1'
-  spec.add_runtime_dependency 'prometheus_exporter', '~> 0.5'
+  spec.add_runtime_dependency 'prometheus_exporter', '~> 0.7'
   spec.add_runtime_dependency 'thin', '~> 1.7'
 end


### PR DESCRIPTION
 Bumping prometheus_exporter gem to support Rails 6.1 upgrade

With Rails 6.1 upgrade https://github.com/bigcommerce/bigpay/pull/3449 , there were errors around prometheus exporter as:
`Prometheus Exporter Failed To Collect Process Stats undefined method spec for #<ActiveRecord::ConnectionAdapters::ConnectionPool:0x00007f91002eef80> `

This issue gets fixed with bumping prometheus_exporter to latest version.
