### PR TITLE
Fix keywords argument issue with Collectors::Base and Ruby 3.0+

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@ Changelog for the bc-prometheus-ruby gem.
 
 ### Pending Release
 
+### 0.5.1
+
+- Fix keywords argument issue with Collectors::Base and Ruby 3.0+
+
 ### 0.5.0
 
 - Add configuration to disable the Railtie that activates the web instrumentor automatically. This allows applications to choose how and when this is initialized.

--- a/lib/bigcommerce/prometheus/collectors/base.rb
+++ b/lib/bigcommerce/prometheus/collectors/base.rb
@@ -25,8 +25,8 @@ module Bigcommerce
         ##
         # Start the collector
         #
-        def self.start(*args, &block)
-          process_collector = new(*args, &block)
+        def self.start(args, &block)
+          process_collector = new(**args, &block)
 
           stop if @thread
 

--- a/spec/bigcommerce/prometheus/collectors/base_spec.rb
+++ b/spec/bigcommerce/prometheus/collectors/base_spec.rb
@@ -22,6 +22,18 @@ describe Bigcommerce::Prometheus::Collectors::Base do
   let(:client) { double(:client, send_json: true) }
   let(:collector) { AppCollector.new(client: client, frequency: 0) }
 
+  describe '#start' do
+    subject { AppCollector.start(client: client, frequency: 0) }
+
+    it 'starts the collector on a thread' do
+      thread = subject
+      expect(thread).to be_a(Thread)
+      expect(thread).to be_alive
+    ensure
+      AppCollector.stop
+    end
+  end
+
   describe '#run' do
     subject { collector.run }
 


### PR DESCRIPTION
Fixes a keyword argument issue with the splat operator and Ruby 3.0+.

This makes it both 2.x and 3.x compatible, and adds tests for the case.

---

@bigcommerce/ruby @bigcommerce/oss-maintainers 