### PR TITLE
Fix the error with accessing a non-existent attribute in the config

### DIFF
--- a/.rspec
+++ b/.rspec
@@ -1,3 +1,2 @@
---format documentation
 --color
 --require spec_helper

--- a/.rspec
+++ b/.rspec
@@ -1,0 +1,3 @@
+--format documentation
+--color
+--require spec_helper

--- a/bc-prometheus-ruby.gemspec
+++ b/bc-prometheus-ruby.gemspec
@@ -36,6 +36,7 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency 'bundler-audit', '>= 0.6'
   spec.add_development_dependency 'null-logger', '>= 0.1'
   spec.add_development_dependency 'pry', '>= 0.12'
+  spec.add_development_dependency 'railties', '>= 6.0.0'
   spec.add_development_dependency 'rake', '>= 10.0'
   spec.add_development_dependency 'rspec', '>= 3.8'
   spec.add_development_dependency 'rspec_junit_formatter', '>= 0.4'

--- a/spec/bigcommerce/prometheus/instrumentors/web_spec.rb
+++ b/spec/bigcommerce/prometheus/instrumentors/web_spec.rb
@@ -1,0 +1,40 @@
+describe Bigcommerce::Prometheus::Instrumentors::Web do
+  def run!
+    described_class.new(app: application).start
+  end
+
+  let(:application) do
+    instance_double(Rails::Application).tap do |instance|
+      allow(instance).to receive(:config).and_return(configuration)
+      allow(instance).to receive(:middleware).and_return(middleware)
+    end
+  end
+
+  let(:configuration) { Rails::Engine::Configuration.new }
+  let(:middleware) { [] }
+
+  it 'properly handles lack of the fork configs' do
+    expect(Bigcommerce::Prometheus.logger).not_to receive(:error)
+
+    run!
+
+    expect(configuration.respond_to?(:before_fork_callbacks)).to eq(true)
+    expect(configuration.respond_to?(:after_fork_callbacks)).to eq(true)
+    expect(configuration.before_fork_callbacks).to be_an_instance_of(Array)
+    expect(configuration.after_fork_callbacks).to be_an_instance_of(Array)
+  end
+
+  context 'when configuration already set' do
+    before do
+      configuration.before_fork_callbacks = [1]
+      configuration.after_fork_callbacks = [1]
+    end
+
+    it 'just adds another elements' do
+      run!
+
+      expect(configuration.before_fork_callbacks.size).to eq(2)
+      expect(configuration.after_fork_callbacks.size).to eq(2)
+    end
+  end
+end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -18,6 +18,7 @@ $LOAD_PATH.unshift File.expand_path('../lib', __dir__)
 require_relative 'simplecov_helper'
 require 'bigcommerce/prometheus'
 require 'pry'
+require 'rails'
 Dir["#{File.join(File.dirname(__FILE__), 'support')}/**/*.rb"].sort.each { |f| require f }
 
 RSpec.configure do |config|


### PR DESCRIPTION
# Changes

## Fixes

- Fixed an error that occurred when checking for the existence of attributes (`before_fork_callbacks`, `after_fork_callbacks`) in the config: when checking the value for nil, we can get a `NoMethodError` if no one has set this attribute before.