### PR TITLE
Better error handling for Ruby 2.7, failure modes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@ Changelog for the bc-prometheus-ruby gem.
 
 ### Pending Release
 
+- Better error handling post-fork for web/resque instrumentors
+- Fix issue with using `Collectors::Base` and keyword arguments in Ruby 2.7
+- Remove null-logger development dependency
+
 ### 0.5.1
 
 - Fix keywords argument issue with Collectors::Base and Ruby 3.0+

--- a/bc-prometheus-ruby.gemspec
+++ b/bc-prometheus-ruby.gemspec
@@ -34,7 +34,6 @@ Gem::Specification.new do |spec|
   spec.required_ruby_version = '>= 2.6'
 
   spec.add_development_dependency 'bundler-audit', '>= 0.6'
-  spec.add_development_dependency 'null-logger', '>= 0.1'
   spec.add_development_dependency 'pry', '>= 0.12'
   spec.add_development_dependency 'rake', '>= 10.0'
   spec.add_development_dependency 'rspec', '>= 3.8'

--- a/lib/bigcommerce/prometheus/collectors/base.rb
+++ b/lib/bigcommerce/prometheus/collectors/base.rb
@@ -25,7 +25,10 @@ module Bigcommerce
         ##
         # Start the collector
         #
-        def self.start(args, &block)
+        # @param [Hash] args
+        #
+        def self.start(args = {}, &block)
+          args ||= {}
           process_collector = new(**args, &block)
 
           stop if @thread

--- a/lib/bigcommerce/prometheus/instrumentors/resque.rb
+++ b/lib/bigcommerce/prometheus/instrumentors/resque.rb
@@ -70,6 +70,8 @@ module Bigcommerce
           ::Resque.before_first_fork do
             ::Bigcommerce::Prometheus::Integrations::Resque.start(client: Bigcommerce::Prometheus.client)
             @collectors.each(&:start)
+          rescue StandardError => e
+            logger.error "[bigcommerce-prometheus][#{@process_name}] Failed to start resque prometheus middleware after fork: #{e.message}"
           end
         end
       end

--- a/lib/bigcommerce/prometheus/instrumentors/web.rb
+++ b/lib/bigcommerce/prometheus/instrumentors/web.rb
@@ -79,13 +79,15 @@ module Bigcommerce
           @app.config.after_fork_callbacks << lambda do
             ::Bigcommerce::Prometheus::Integrations::Puma.start(client: Bigcommerce::Prometheus.client)
             @collectors.each(&:start)
+          rescue StandardError => e
+            logger.error "[bigcommerce-prometheus][#{@process_name}] Failed to start web prometheus middleware after fork: #{e.message}"
           end
         end
 
         def setup_middleware
           @app.middleware.unshift(PrometheusExporter::Middleware, client: Bigcommerce::Prometheus.client)
         rescue StandardError => e
-          logger.warn "[bc-prometheus-ruby] Failed to attach app middleware in web instrumentor: #{e.message}"
+          logger.warn "[bigcommerce-prometheus] Failed to attach app middleware in web instrumentor: #{e.message}"
         end
       end
     end

--- a/spec/support/logging.rb
+++ b/spec/support/logging.rb
@@ -15,8 +15,6 @@
 # COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR
 # OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 #
-require 'null_logger'
-
 module LoggerHelper
   def logger
     Bigcommerce::Prometheus.logger
@@ -25,7 +23,7 @@ end
 
 RSpec.configure do |config|
   config.before do
-    Bigcommerce::Prometheus.logger = NullLogger.new unless ENV.fetch('DEBUG', 0).to_i.positive?
+    Bigcommerce::Prometheus.logger = ::Logger.new(::File::NULL) unless ::ENV.fetch('DEBUG', 0).to_i.positive?
   end
 
   include LoggerHelper


### PR DESCRIPTION
- Better error handling post-fork for web/resque instrumentors
- Fix issue with using `Collectors::Base` and keyword arguments in Ruby 2.7
- Remove null-logger development dependency