### PR TITLE
Remove Ruby 2.x support

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -7,12 +7,6 @@ orbs:
 defaults: &defaults
   notify_failure: false
 
-ruby_2_7_defaults: &ruby_2_7_defaults
-  <<: *defaults
-  e:
-    name: ruby/ruby
-    ruby-version: '2.7'
-
 ruby_3_0_defaults: &ruby_3_0_defaults
   <<: *defaults
   e:
@@ -27,19 +21,6 @@ ruby_3_1_defaults: &ruby_3_1_defaults
 
 workflows:
   version: 2
-  ruby_2_7:
-    jobs:
-      - ruby/bundle-audit:
-          <<: *ruby_2_7_defaults
-          name: ruby-2_7-bundle_audit
-      - ruby/rubocop:
-          <<: *ruby_2_7_defaults
-          name: ruby-2_7-rubocop
-      - ruby/rspec-unit:
-          <<: *ruby_2_7_defaults
-          name: ruby-2_7-rspec_unit
-          db: false
-          code-climate: false
   ruby_3_0:
     jobs:
       - ruby/bundle-audit:

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,5 +1,5 @@
 AllCops:
-  TargetRubyVersion: 2.7
+  TargetRubyVersion: 3.0
   Exclude:
     - spec/**/*
     - .bundle/**/*

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@ Changelog for the bc-prometheus-ruby gem.
 ### Pending Release
 
 - Add support for Ruby 3.1
-- Drop support for Ruby 2.6
+- Drop support for Ruby 2
 - Add CodeClimate analysis
 
 ## 0.5.2

--- a/bc-prometheus-ruby.gemspec
+++ b/bc-prometheus-ruby.gemspec
@@ -31,7 +31,7 @@ Gem::Specification.new do |spec|
 
   spec.files         = Dir['README.md', 'CHANGELOG.md', 'CODE_OF_CONDUCT.md', 'lib/**/*', 'bc-prometheus-ruby.gemspec']
   spec.require_paths = ['lib']
-  spec.required_ruby_version = '>= 2.7'
+  spec.required_ruby_version = '>= 3.0'
 
   spec.add_development_dependency 'bundler-audit', '>= 0.6'
   spec.add_development_dependency 'pry', '>= 0.12'

--- a/lib/bigcommerce/prometheus/version.rb
+++ b/lib/bigcommerce/prometheus/version.rb
@@ -17,6 +17,6 @@
 #
 module Bigcommerce
   module Prometheus
-    VERSION = '0.5.3.pre'
+    VERSION = '0.6.0.pre'
   end
 end

--- a/spec/bigcommerce/prometheus/collectors/base_spec.rb
+++ b/spec/bigcommerce/prometheus/collectors/base_spec.rb
@@ -38,10 +38,10 @@ describe Bigcommerce::Prometheus::Collectors::Base do
     subject { collector.run }
 
     it 'collects and pushes the metrics, then sleeps the frequency' do
-      expect(client).to receive(:send_json).with(
+      expect(client).to receive(:send_json).with({
         type: 'app',
         points: 42
-      ).once
+      }).once
       subject
     end
   end
@@ -50,13 +50,13 @@ describe Bigcommerce::Prometheus::Collectors::Base do
     subject { collector.honk! }
 
     it 'pushes the metric dynamically' do
-      expect(client).to receive(:send_json).with(
+      expect(client).to receive(:send_json).with({
         type: 'app',
         honks: 1,
         custom_labels: {
           volume: 'loud'
         }
-      ).once
+      }).once
       subject
     end
   end


### PR DESCRIPTION
## What?

As per the Ruby 2.x EOL life schedule, this repository will be removing Ruby 2.x support.