### PR TITLE
update the readme file for starting prometheus with puma

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,6 +14,14 @@ Then in your `application.rb`, prior to extending `Rails::Application` or any in
 require 'bigcommerce/prometheus'
 ```
 
+Then in your web server config file (e.g. `puma.rb`)
+
+```ruby
+before_fork do
+  Rails.application.config.before_fork_callbacks.each(&:call)
+end
+```
+
 You can then view your metrics at: http://0.0.0.0:9394/metrics
 
 ## Puma
@@ -21,10 +29,6 @@ You can then view your metrics at: http://0.0.0.0:9394/metrics
 For extra Puma metrics, add this to `config/puma.rb`:
 
 ```ruby
-before_fork do
-  Rails.application.config.before_fork_callbacks.each(&:call)
-end
-
 after_worker_fork do
   Rails.application.config.after_fork_callbacks.each(&:call)
 end

--- a/README.md
+++ b/README.md
@@ -21,6 +21,10 @@ You can then view your metrics at: http://0.0.0.0:9394/metrics
 For extra Puma metrics, add this to `config/puma.rb`:
 
 ```ruby
+before_fork do
+  Rails.application.config.before_fork_callbacks.each(&:call)
+end
+
 after_worker_fork do
   Rails.application.config.after_fork_callbacks.each(&:call)
 end


### PR DESCRIPTION
We found an issue with initializing the prometheus server when the `before_fork` hook was missing in the `puma.rb` file. For repos that don't have this line in the web server config the prometheus server never starts as the callback is never called. Updating the readme so it helps posterity in the setup process.