### PR TITLE
Add logging when the prometheus server starts

### DIFF
--- a/lib/bigcommerce/prometheus/servers/thin/server.rb
+++ b/lib/bigcommerce/prometheus/servers/thin/server.rb
@@ -31,7 +31,9 @@ module Bigcommerce
             @rack_app = ::Bigcommerce::Prometheus::Servers::Thin::RackApp.new(timeout: timeout, logger: logger)
             super(@host, @port, @rack_app)
             ::Thin::Logging.logger = @logger
-            @logger.info "[bigcommerce-prometheus] Prometheus server started on #{@host}:#{@port}"
+            server_started = "[bigcommerce-prometheus] Prometheus server started on #{@host}:#{@port}"
+            @logger.info server_started
+            $stdout.puts server_started
             self.threadpool_size = (thread_pool_size || ::Bigcommerce::Prometheus.server_thread_pool_size).to_i
           end
 

--- a/lib/bigcommerce/prometheus/servers/thin/server.rb
+++ b/lib/bigcommerce/prometheus/servers/thin/server.rb
@@ -31,6 +31,7 @@ module Bigcommerce
             @rack_app = ::Bigcommerce::Prometheus::Servers::Thin::RackApp.new(timeout: timeout, logger: logger)
             super(@host, @port, @rack_app)
             ::Thin::Logging.logger = @logger
+            @logger.info "[bigcommerce-prometheus] Prometheus server started on #{@host}:#{@port}"
             self.threadpool_size = (thread_pool_size || ::Bigcommerce::Prometheus.server_thread_pool_size).to_i
           end
 

--- a/lib/bigcommerce/prometheus/servers/thin/server.rb
+++ b/lib/bigcommerce/prometheus/servers/thin/server.rb
@@ -31,9 +31,7 @@ module Bigcommerce
             @rack_app = ::Bigcommerce::Prometheus::Servers::Thin::RackApp.new(timeout: timeout, logger: logger)
             super(@host, @port, @rack_app)
             ::Thin::Logging.logger = @logger
-            server_started = "[bigcommerce-prometheus] Prometheus server started on #{@host}:#{@port}"
-            @logger.info server_started
-            $stdout.puts server_started
+            @logger.info "[bigcommerce-prometheus] Prometheus server started on #{@host}:#{@port}"
             self.threadpool_size = (thread_pool_size || ::Bigcommerce::Prometheus.server_thread_pool_size).to_i
           end
 


### PR DESCRIPTION
## What? Why?

We had an incident recently where health checks were failing. One of the callouts while investigating was that there was no logs indicating that the prometheus server had started successfully. This change adds a log line for server startup so we can confirm the metrics server is up and running. I set the log level to info as we only need this during debugging and don't need this info normally.


## How was it tested?

Proof of life

<img width="1512" alt="image" src="https://github.com/bigcommerce/bc-prometheus-ruby/assets/48609023/de34fc09-247b-4642-ad26-4c358bff1289">


