### PR TITLE
Migrate from thin to puma for the web server

### DIFF
--- a/bc-prometheus-ruby.gemspec
+++ b/bc-prometheus-ruby.gemspec
@@ -35,6 +35,7 @@ Gem::Specification.new do |spec|
 
   spec.add_runtime_dependency 'bigcommerce-multitrap', '~> 0.1'
   spec.add_runtime_dependency 'prometheus_exporter', '~> 0.7'
+  spec.add_runtime_dependency 'puma', '> 5'
+  spec.add_runtime_dependency 'rack', '>= 3.0'
   spec.add_runtime_dependency 'rake', '>= 10.0'
-  spec.add_runtime_dependency 'thin', '~> 1.7'
 end

--- a/lib/bigcommerce/prometheus.rb
+++ b/lib/bigcommerce/prometheus.rb
@@ -22,7 +22,8 @@ require 'prometheus_exporter/server'
 require 'prometheus_exporter/client'
 require 'prometheus_exporter/middleware'
 require 'prometheus_exporter/instrumentation'
-require 'thin'
+require 'puma'
+require 'rack'
 
 require_relative 'prometheus/version'
 require_relative 'prometheus/loggable'
@@ -42,14 +43,14 @@ require_relative 'prometheus/integrations/railtie' if defined?(Rails)
 require_relative 'prometheus/integrations/puma'
 require_relative 'prometheus/integrations/resque'
 
-require_relative 'prometheus/servers/thin/server'
-require_relative 'prometheus/servers/thin/rack_app'
-require_relative 'prometheus/servers/thin/server_metrics'
-require_relative 'prometheus/servers/thin/controllers/base_controller'
-require_relative 'prometheus/servers/thin/controllers/error_controller'
-require_relative 'prometheus/servers/thin/controllers/metrics_controller'
-require_relative 'prometheus/servers/thin/controllers/not_found_controller'
-require_relative 'prometheus/servers/thin/controllers/send_metrics_controller'
+require_relative 'prometheus/servers/puma/server'
+require_relative 'prometheus/servers/puma/rack_app'
+require_relative 'prometheus/servers/puma/server_metrics'
+require_relative 'prometheus/servers/puma/controllers/base_controller'
+require_relative 'prometheus/servers/puma/controllers/error_controller'
+require_relative 'prometheus/servers/puma/controllers/metrics_controller'
+require_relative 'prometheus/servers/puma/controllers/not_found_controller'
+require_relative 'prometheus/servers/puma/controllers/send_metrics_controller'
 
 module Bigcommerce
   ##

--- a/lib/bigcommerce/prometheus/server.rb
+++ b/lib/bigcommerce/prometheus/server.rb
@@ -35,7 +35,7 @@ module Bigcommerce
         @prefix = (prefix || ::PrometheusExporter::DEFAULT_PREFIX).to_s
         @process_name = ::Bigcommerce::Prometheus.process_name
         @logger = logger || ::Bigcommerce::Prometheus.logger
-        @server = ::Bigcommerce::Prometheus::Servers::Thin::Server.new(
+        @server = ::Bigcommerce::Prometheus::Servers::Puma::Server.new(
           port: @port,
           timeout: @timeout,
           logger: @logger,

--- a/lib/bigcommerce/prometheus/server.rb
+++ b/lib/bigcommerce/prometheus/server.rb
@@ -55,7 +55,7 @@ module Bigcommerce
         @run_thread = @server.run
         @running = true
 
-        @logger.info "[bigcommerce-prometheus][#{@process_name}] Prometheus exporter started on #{@host}:#{@port} with #{@server.pool_capacity} threads"
+        @logger.info "[bigcommerce-prometheus][#{@process_name}] Prometheus exporter started on #{@host}:#{@port} with #{@server.max_threads} threads"
 
         @server
       rescue ::StandardError => e

--- a/lib/bigcommerce/prometheus/server.rb
+++ b/lib/bigcommerce/prometheus/server.rb
@@ -52,12 +52,10 @@ module Bigcommerce
       def start
         @logger.info "[bigcommerce-prometheus][#{@process_name}] Starting prometheus exporter on port #{@host}:#{@port}"
 
-        @run_thread = ::Thread.start do
-          @server.start
-        end
+        @run_thread = @server.run
         @running = true
 
-        @logger.info "[bigcommerce-prometheus][#{@process_name}] Prometheus exporter started on #{@host}:#{@port} with #{@server.threadpool_size} threads"
+        @logger.info "[bigcommerce-prometheus][#{@process_name}] Prometheus exporter started on #{@host}:#{@port} with #{@server.pool_capacity} threads"
 
         @server
       rescue ::StandardError => e
@@ -81,7 +79,7 @@ module Bigcommerce
       # Stop the server
       #
       def stop
-        @server.stop!
+        @server.stop
         @run_thread.kill
         @running = false
         $stdout.puts "[bigcommerce-prometheus][#{@process_name}] Prometheus exporter cleanly shut down"

--- a/lib/bigcommerce/prometheus/servers/puma/controllers/error_controller.rb
+++ b/lib/bigcommerce/prometheus/servers/puma/controllers/error_controller.rb
@@ -18,42 +18,15 @@
 module Bigcommerce
   module Prometheus
     module Servers
-      module Thin
+      module Puma
         module Controllers
           ##
-          # Base thin controller for prometheus metrics
+          # Handle 500s
           #
-          class BaseController
-            ##
-            # @param [Rack::Request] request
-            # @param [Rack::Response] response
-            # @param [Bigcommerce::Prometheus::Servers::Thin::ServerMetrics]
-            # @param [PrometheusExporter::Server::Collector] collector
-            # @param [Logger] logger
-            #
-            def initialize(request:, response:, server_metrics:, collector:, logger:)
-              @request = request
-              @response = response
-              @collector = collector
-              @server_metrics = server_metrics
-              @logger = logger
-            end
-
-            def handle
-              call
-              @response.finish
-            end
-
-            ##
-            # @param [String] key
-            # @param [String] value
-            #
-            def set_header(key, value)
-              if @response.respond_to?(:add_header) # rack 2.0+
-                @response.add_header(key.to_s, value.to_s)
-              else
-                @response[key.to_s] = value.to_s
-              end
+          class ErrorController < BaseController
+            def call
+              @response.body << ''
+              @response.status = 500
             end
           end
         end

--- a/lib/bigcommerce/prometheus/servers/puma/controllers/metrics_controller.rb
+++ b/lib/bigcommerce/prometheus/servers/puma/controllers/metrics_controller.rb
@@ -22,7 +22,7 @@ require 'stringio'
 module Bigcommerce
   module Prometheus
     module Servers
-      module Thin
+      module Puma
         module Controllers
           ##
           # GET /metrics

--- a/lib/bigcommerce/prometheus/servers/puma/controllers/not_found_controller.rb
+++ b/lib/bigcommerce/prometheus/servers/puma/controllers/not_found_controller.rb
@@ -18,7 +18,7 @@
 module Bigcommerce
   module Prometheus
     module Servers
-      module Thin
+      module Puma
         module Controllers
           ##
           # Handle invalid requests to server

--- a/lib/bigcommerce/prometheus/servers/puma/controllers/send_metrics_controller.rb
+++ b/lib/bigcommerce/prometheus/servers/puma/controllers/send_metrics_controller.rb
@@ -18,7 +18,7 @@
 module Bigcommerce
   module Prometheus
     module Servers
-      module Thin
+      module Puma
         module Controllers
           ##
           # POST /send-metrics

--- a/lib/bigcommerce/prometheus/servers/puma/rack_app.rb
+++ b/lib/bigcommerce/prometheus/servers/puma/rack_app.rb
@@ -18,9 +18,9 @@
 module Bigcommerce
   module Prometheus
     module Servers
-      module Thin
+      module Puma
         ##
-        # Handles metrics requests as a Rack App on the Thin server
+        # Handles metrics requests as a Rack App on the Puma server
         #
         class RackApp
           ##
@@ -29,7 +29,7 @@ module Bigcommerce
             @timeout = timeout || ::Bigcommerce::Prometheus.server_timeout
             @collector = collector || ::PrometheusExporter::Server::Collector.new
             @logger = logger || ::Bigcommerce::Prometheus.logger
-            @server_metrics = ::Bigcommerce::Prometheus::Servers::Thin::ServerMetrics.new(logger: @logger)
+            @server_metrics = ::Bigcommerce::Prometheus::Servers::Puma::ServerMetrics.new(logger: @logger)
           end
 
           def call(env)
@@ -39,7 +39,7 @@ module Bigcommerce
             handle(controller: controller, request: request, response: response)
           rescue StandardError => e
             @logger.error "Error: #{e.message}"
-            handle(controller: ::Bigcommerce::Prometheus::Servers::Thin::Controllers::ErrorController, request: request, response: response)
+            handle(controller: ::Bigcommerce::Prometheus::Servers::Puma::Controllers::ErrorController, request: request, response: response)
           end
 
           ##
@@ -60,11 +60,11 @@ module Bigcommerce
           #
           def route(request)
             if request.fullpath == '/metrics' && request.request_method.to_s.downcase == 'get'
-              Bigcommerce::Prometheus::Servers::Thin::Controllers::MetricsController
+              Bigcommerce::Prometheus::Servers::Puma::Controllers::MetricsController
             elsif request.fullpath == '/send-metrics' && request.request_method.to_s.downcase == 'post'
-              Bigcommerce::Prometheus::Servers::Thin::Controllers::SendMetricsController
+              Bigcommerce::Prometheus::Servers::Puma::Controllers::SendMetricsController
             else
-              Bigcommerce::Prometheus::Servers::Thin::Controllers::NotFoundController
+              Bigcommerce::Prometheus::Servers::Puma::Controllers::NotFoundController
             end
           end
 

--- a/lib/bigcommerce/prometheus/servers/puma/server.rb
+++ b/lib/bigcommerce/prometheus/servers/puma/server.rb
@@ -18,21 +18,21 @@
 module Bigcommerce
   module Prometheus
     module Servers
-      module Thin
+      module Puma
         ##
-        # Thin adapter for server
+        # Puma adapter for server
         #
-        class Server < ::Thin::Server
+        class Server < ::Puma::Server
           def initialize(port: nil, host: nil, timeout: nil, logger: nil, thread_pool_size: nil)
             @port = port || ::Bigcommerce::Prometheus.server_port
             @host = host || ::Bigcommerce::Prometheus.server_host
             @timeout = timeout || ::Bigcommerce::Prometheus.server_timeout
             @logger = logger || ::Bigcommerce::Prometheus.logger
-            @rack_app = ::Bigcommerce::Prometheus::Servers::Thin::RackApp.new(timeout: timeout, logger: logger)
-            super(@host, @port, @rack_app)
-            ::Thin::Logging.logger = @logger
+            @rack_app = ::Bigcommerce::Prometheus::Servers::Puma::RackApp.new(timeout: timeout, logger: logger)
+            thread_pool_size = (thread_pool_size || ::Bigcommerce::Prometheus.server_thread_pool_size).to_i
+            super(@app, nil, max_threads: thread_pool_size)
+            add_tcp_listener(@host, @port)
             @logger.info "[bigcommerce-prometheus] Prometheus server started on #{@host}:#{@port}"
-            self.threadpool_size = (thread_pool_size || ::Bigcommerce::Prometheus.server_thread_pool_size).to_i
           end
 
           ##

--- a/lib/bigcommerce/prometheus/servers/puma/server.rb
+++ b/lib/bigcommerce/prometheus/servers/puma/server.rb
@@ -30,7 +30,7 @@ module Bigcommerce
             @logger = logger || ::Bigcommerce::Prometheus.logger
             @rack_app = ::Bigcommerce::Prometheus::Servers::Puma::RackApp.new(timeout: timeout, logger: logger)
             thread_pool_size = (thread_pool_size || ::Bigcommerce::Prometheus.server_thread_pool_size).to_i
-            super(@app, nil, max_threads: thread_pool_size)
+            super(@rack_app, nil, max_threads: thread_pool_size)
             add_tcp_listener(@host, @port)
             @logger.info "[bigcommerce-prometheus] Prometheus server started on #{@host}:#{@port}"
           end

--- a/lib/bigcommerce/prometheus/servers/puma/server_metrics.rb
+++ b/lib/bigcommerce/prometheus/servers/puma/server_metrics.rb
@@ -22,7 +22,7 @@ require 'stringio'
 module Bigcommerce
   module Prometheus
     module Servers
-      module Thin
+      module Puma
         ##
         # Server metrics for the collector
         #

--- a/spec/bigcommerce/prometheus/servers/puma/controllers/metrics_controller_spec.rb
+++ b/spec/bigcommerce/prometheus/servers/puma/controllers/metrics_controller_spec.rb
@@ -15,8 +15,8 @@
 #
 require 'spec_helper'
 
-describe Bigcommerce::Prometheus::Servers::Thin::Controllers::SendMetricsController do
-  let(:request_method) { 'POST' }
+describe Bigcommerce::Prometheus::Servers::Puma::Controllers::MetricsController do
+  let(:request_method) { 'GET' }
   let(:env) do
     {
       'REQUEST_METHOD' => request_method,
@@ -27,46 +27,40 @@ describe Bigcommerce::Prometheus::Servers::Thin::Controllers::SendMetricsControl
   let(:request) { Rack::Request.new(env) }
   let(:response) { Rack::Response.new }
   let(:collector) { PrometheusExporter::Server::Collector.new }
-  let(:server_metrics) { Bigcommerce::Prometheus::Servers::Thin::ServerMetrics.new }
+  let(:server_metrics) { Bigcommerce::Prometheus::Servers::Puma::ServerMetrics.new }
   let(:controller) { described_class.new(request: request, response: response, server_metrics: server_metrics, collector: collector, logger: logger) }
+
+  let(:metrics) { ['ruby_collector_metrics_total 19', 'ruby_collector_sessions_total 19'].join("\n") }
+  let(:server_metrics_text) { ['collector_working 1', 'collector_rss 60440'].join("\n") }
+
+  before do
+    allow(collector).to receive(:prometheus_metrics_text).and_return(metrics)
+    allow(server_metrics).to receive(:to_prometheus_text).and_return(server_metrics_text)
+  end
 
   describe '#call' do
     subject { controller.call }
 
-    context 'when a post request' do
-      context 'when the collector properly parses the metrics' do
-        before do
-          expect(collector).to receive(:process).once
-        end
-
-        it 'succeeds' do
-          expect(subject.status).to eq 200
-          expect(subject.body.first).to eq 'OK'
-        end
-      end
-
-      context 'when the collector fails to parse the metrics' do
-        let(:error_message) { 'failure!' }
-        let(:exception) { StandardError.new(error_message) }
-        before do
-          expect(collector).to receive(:process).once.and_raise(exception)
-        end
-
-        it 'fails' do
-          expect(subject.status).to eq 500
-          parsed_body = JSON.parse(subject.body.first)
-          expect(parsed_body).to eq [error_message]
-        end
-      end
+    it 'succeeds' do
+      expect(subject.status).to eq 200
+      expect(subject.body.first).to eq 'collector_working 1
+collector_rss 60440
+ruby_collector_metrics_total 19
+ruby_collector_sessions_total 19'
     end
 
-    context 'when not a post request' do
-      let(:request_method) { 'GET' }
+    context 'when the metrics fail to parse' do
+      let(:timeout_exception) { ::Timeout::Error }
+      before do
+        allow(collector).to receive(:prometheus_metrics_text).and_raise(timeout_exception)
+      end
 
-      it 'fails' do
-        expect(subject.status).to eq 500
-        parsed_body = JSON.parse(subject.body.first)
-        expect(parsed_body).to eq ['Invalid request type. Only POST is supported.']
+      it 'still responds 200, but logs an error' do
+        expect(logger).to receive(:error).with('Generating Prometheus metrics text timed out')
+        expect(subject.status).to eq 200
+        expect(subject.body.first).to eq 'collector_working 1
+collector_rss 60440
+'
       end
     end
   end

--- a/spec/bigcommerce/prometheus/servers/puma/controllers/send_metrics_controller_spec.rb
+++ b/spec/bigcommerce/prometheus/servers/puma/controllers/send_metrics_controller_spec.rb
@@ -15,8 +15,8 @@
 #
 require 'spec_helper'
 
-describe Bigcommerce::Prometheus::Servers::Thin::Controllers::MetricsController do
-  let(:request_method) { 'GET' }
+describe Bigcommerce::Prometheus::Servers::Puma::Controllers::SendMetricsController do
+  let(:request_method) { 'POST' }
   let(:env) do
     {
       'REQUEST_METHOD' => request_method,
@@ -27,40 +27,46 @@ describe Bigcommerce::Prometheus::Servers::Thin::Controllers::MetricsController 
   let(:request) { Rack::Request.new(env) }
   let(:response) { Rack::Response.new }
   let(:collector) { PrometheusExporter::Server::Collector.new }
-  let(:server_metrics) { Bigcommerce::Prometheus::Servers::Thin::ServerMetrics.new }
+  let(:server_metrics) { Bigcommerce::Prometheus::Servers::Puma::ServerMetrics.new }
   let(:controller) { described_class.new(request: request, response: response, server_metrics: server_metrics, collector: collector, logger: logger) }
-
-  let(:metrics) { ['ruby_collector_metrics_total 19', 'ruby_collector_sessions_total 19'].join("\n") }
-  let(:server_metrics_text) { ['collector_working 1', 'collector_rss 60440'].join("\n") }
-
-  before do
-    allow(collector).to receive(:prometheus_metrics_text).and_return(metrics)
-    allow(server_metrics).to receive(:to_prometheus_text).and_return(server_metrics_text)
-  end
 
   describe '#call' do
     subject { controller.call }
 
-    it 'succeeds' do
-      expect(subject.status).to eq 200
-      expect(subject.body.first).to eq 'collector_working 1
-collector_rss 60440
-ruby_collector_metrics_total 19
-ruby_collector_sessions_total 19'
-    end
+    context 'when a post request' do
+      context 'when the collector properly parses the metrics' do
+        before do
+          expect(collector).to receive(:process).once
+        end
 
-    context 'when the metrics fail to parse' do
-      let(:timeout_exception) { ::Timeout::Error }
-      before do
-        allow(collector).to receive(:prometheus_metrics_text).and_raise(timeout_exception)
+        it 'succeeds' do
+          expect(subject.status).to eq 200
+          expect(subject.body.first).to eq 'OK'
+        end
       end
 
-      it 'still responds 200, but logs an error' do
-        expect(logger).to receive(:error).with('Generating Prometheus metrics text timed out')
-        expect(subject.status).to eq 200
-        expect(subject.body.first).to eq 'collector_working 1
-collector_rss 60440
-'
+      context 'when the collector fails to parse the metrics' do
+        let(:error_message) { 'failure!' }
+        let(:exception) { StandardError.new(error_message) }
+        before do
+          expect(collector).to receive(:process).once.and_raise(exception)
+        end
+
+        it 'fails' do
+          expect(subject.status).to eq 500
+          parsed_body = JSON.parse(subject.body.first)
+          expect(parsed_body).to eq [error_message]
+        end
+      end
+    end
+
+    context 'when not a post request' do
+      let(:request_method) { 'GET' }
+
+      it 'fails' do
+        expect(subject.status).to eq 500
+        parsed_body = JSON.parse(subject.body.first)
+        expect(parsed_body).to eq ['Invalid request type. Only POST is supported.']
       end
     end
   end

--- a/spec/bigcommerce/prometheus/servers/puma/server_spec.rb
+++ b/spec/bigcommerce/prometheus/servers/puma/server_spec.rb
@@ -1,7 +1,7 @@
 require 'spec_helper'
 
-describe Bigcommerce::Prometheus::Servers::Thin::Server do
-  let(:server) { described_class.new }
+describe Bigcommerce::Prometheus::Servers::Puma::Server do
+  let(:server) { described_class.new(port: 9800+rand(100)) }
 
   before do
     Bigcommerce::Prometheus.reset
@@ -9,8 +9,8 @@ describe Bigcommerce::Prometheus::Servers::Thin::Server do
 
   context 'when the thread pool size is not configured' do
     it 'falls back to the default configuration' do
-      expect(server.threadpool_size).to eq ::Bigcommerce::Prometheus.server_thread_pool_size
-      expect(server.threadpool_size).to eq 3
+      expect(server.max_threads).to eq ::Bigcommerce::Prometheus.server_thread_pool_size
+      expect(server.max_threads).to eq 3
     end
   end
 
@@ -24,7 +24,7 @@ describe Bigcommerce::Prometheus::Servers::Thin::Server do
     end
 
     it 'allows you to set the thread pool size through the configuration block' do
-      expect(server.threadpool_size).to eq server_thread_pool_size
+      expect(server.max_threads).to eq server_thread_pool_size
     end
   end
 end

--- a/spec/bigcommerce/prometheus/servers/puma/server_spec.rb
+++ b/spec/bigcommerce/prometheus/servers/puma/server_spec.rb
@@ -1,10 +1,16 @@
 require 'spec_helper'
 
 describe Bigcommerce::Prometheus::Servers::Puma::Server do
-  let(:server) { described_class.new(port: 9800+rand(100)) }
-
+  let(:server) { described_class.new(port: default_port) }
+  let(:default_port) { 9800 + rand(100) }
   before do
     Bigcommerce::Prometheus.reset
+  end
+
+  context 'when the server is initialized' do
+    it 'has a valid rack app' do
+      expect(server.app).to be_a(Bigcommerce::Prometheus::Servers::Puma::RackApp)
+    end
   end
 
   context 'when the thread pool size is not configured' do
@@ -25,6 +31,21 @@ describe Bigcommerce::Prometheus::Servers::Puma::Server do
 
     it 'allows you to set the thread pool size through the configuration block' do
       expect(server.max_threads).to eq server_thread_pool_size
+    end
+  end
+
+  context 'when the default port is configured' do
+    let(:server_port) { 9000 + rand(100) }
+    let(:default_port) { nil }
+
+    before do
+      Bigcommerce::Prometheus.configure do |c|
+        c.server_port = server_port
+      end
+    end
+
+    it 'allows you to set the port through the configuration block' do
+      expect(server.connected_ports).to include server_port
     end
   end
 end


### PR DESCRIPTION
## What? Why?

Thin still does [not support Rack 3.0](https://github.com/macournoyer/thin/pull/399), which is needed because Sinatra needs an update due to https://github.com/advisories/GHSA-hxx2-7vcw-mqr3. 

Given the Thin update is almost a year old, this PR migrates from Thin to Puma as the server for metrics.

## How was it tested?

Integrated with a Rails app:

```
❯ curl 0.0.0.0:9466/metrics
# HELP ruby_collector_metrics_total Total metrics processed by exporter.
# TYPE ruby_collector_metrics_total counter
ruby_collector_metrics_total 4


# HELP ruby_collector_sessions_total Total send_metric sessions processed by exporter.
# TYPE ruby_collector_sessions_total counter
ruby_collector_sessions_total 4


# HELP ruby_collector_bad_metrics_total Total mis-handled metrics by collector.
# TYPE ruby_collector_bad_metrics_total counter



# HELP ruby_collector_working Is the main process collector able to collect metrics
# TYPE ruby_collector_working gauge
ruby_collector_working 1


# HELP ruby_collector_rss total memory used by collector process
# TYPE ruby_collector_rss gauge
ruby_collector_rss 127296

# HELP ruby_heap_free_slots Free ruby heap slots.
# TYPE ruby_heap_free_slots gauge
ruby_heap_free_slots{type="web",pid="12741"} 48754

# HELP ruby_heap_live_slots Used ruby heap slots.
# TYPE ruby_heap_live_slots gauge
ruby_heap_live_slots{type="web",pid="12741"} 477767

# HELP ruby_rss Total RSS used by process.
# TYPE ruby_rss gauge
ruby_rss{type="web",pid="12741"} 0

# HELP ruby_major_gc_ops_total Major GC operations by process.
# TYPE ruby_major_gc_ops_total counter
ruby_major_gc_ops_total{type="web",pid="12741"} 9

# HELP ruby_minor_gc_ops_total Minor GC operations by process.
# TYPE ruby_minor_gc_ops_total counter
ruby_minor_gc_ops_total{type="web",pid="12741"} 56

# HELP ruby_allocated_objects_total Total number of allocated objects by process.
# TYPE ruby_allocated_objects_total counter
ruby_allocated_objects_total{type="web",pid="12741"} 3003928

# HELP ruby_puma_workers_total Number of puma workers.
# TYPE ruby_puma_workers_total gauge
ruby_puma_workers_total{phase="0"} 3

# HELP ruby_puma_booted_workers_total Number of puma workers booted.
# TYPE ruby_puma_booted_workers_total gauge
ruby_puma_booted_workers_total{phase="0"} 0

# HELP ruby_puma_old_workers_total Number of old puma workers.
# TYPE ruby_puma_old_workers_total gauge
ruby_puma_old_workers_total{phase="0"} 0
```

Resident set size (RSS) graph for a simple Rails app.  14:45-16:00 is the period we had this deployed (along with an upgrade from Rails 7.0 to 7.1). The memory footprint *does* grow, but only by about 3mb.

<img width="1595" alt="Screenshot 2024-12-10 at 8 26 44 AM" src="https://github.com/user-attachments/assets/667910a2-ab52-4a28-9c67-263549cc626c">
