### PR TITLE
Add Ruby 3.4 support, drop Ruby 3.0, 3.1

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -7,18 +7,6 @@ orbs:
 defaults: &defaults
   notify_failure: false
 
-ruby_3_0_defaults: &ruby_3_0_defaults
-  <<: *defaults
-  e:
-    name: ruby/ruby
-    ruby-version: '3.0'
-
-ruby_3_1_defaults: &ruby_3_1_defaults
-  <<: *defaults
-  e:
-    name: ruby/ruby
-    ruby-version: '3.1'
-
 ruby_3_2_defaults: &ruby_3_2_defaults
   <<: *defaults
   e:
@@ -31,33 +19,14 @@ ruby_3_3_defaults: &ruby_3_3_defaults
     name: ruby/ruby
     ruby-version: '3.3'
 
+ruby_3_4_defaults: &ruby_3_4_defaults
+  <<: *defaults
+  e:
+    name: ruby/ruby
+    ruby-version: '3.4'
+
 workflows:
   version: 2
-  ruby_3_0:
-    jobs:
-      - ruby/bundle-audit:
-          <<: *ruby_3_0_defaults
-          name: ruby-3_0-bundle_audit
-      - ruby/rubocop:
-          <<: *ruby_3_0_defaults
-          name: ruby-3_0-rubocop
-      - ruby/rspec-unit:
-          <<: *ruby_3_0_defaults
-          name: ruby-3_0-rspec_unit
-          db: false
-  ruby_3_1:
-    jobs:
-      - ruby/bundle-audit:
-          <<: *ruby_3_1_defaults
-          name: ruby-3_1-bundle_audit
-      - ruby/rubocop:
-          <<: *ruby_3_1_defaults
-          name: ruby-3_1-rubocop
-      - ruby/rspec-unit:
-          <<: *ruby_3_1_defaults
-          name: ruby-3_1-rspec_unit
-          db: false
-          code-climate: false
   ruby_3_2:
     jobs:
       - ruby/bundle-audit:
@@ -70,7 +39,6 @@ workflows:
           <<: *ruby_3_2_defaults
           name: ruby-3_2-rspec_unit
           db: false
-          code-climate: false
   ruby_3_3:
     jobs:
       - ruby/bundle-audit:
@@ -78,9 +46,20 @@ workflows:
           name: ruby-3_3-bundle_audit
       - ruby/rubocop:
           <<: *ruby_3_3_defaults
-          name: ruby-3_32-rubocop
+          name: ruby-3_3-rubocop
       - ruby/rspec-unit:
           <<: *ruby_3_3_defaults
           name: ruby-3_3-rspec_unit
           db: false
-          code-climate: false
+  ruby_3_4:
+    jobs:
+      - ruby/bundle-audit:
+          <<: *ruby_3_4_defaults
+          name: ruby-3_4-bundle_audit
+      - ruby/rubocop:
+          <<: *ruby_3_4_defaults
+          name: ruby-3_4-rubocop
+      - ruby/rspec-unit:
+          <<: *ruby_3_4_defaults
+          name: ruby-3_4-rspec_unit
+          db: false

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,5 +1,5 @@
 AllCops:
-  TargetRubyVersion: 3.0
+  TargetRubyVersion: 3.2
   Exclude:
     - spec/**/*
     - .bundle/**/*
@@ -8,6 +8,9 @@ AllCops:
     - tmp/**/*
     - log/**/*
     - Rakefile
+plugins:
+  - rubocop-performance
+  - rubocop-rspec
 
 # Allow *VALID_CONFIG_KEYS.keys
 Lint/AmbiguousOperator:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@ Changelog for the bc-prometheus-ruby gem.
 
 ### Pending Release
 
+- Add support for Ruby 3.4
+- Drop support for Ruby 3.0, 3.1
+
 ## 0.7.0
 
 - Add CI suite for Ruby 3.3

--- a/Gemfile
+++ b/Gemfile
@@ -22,6 +22,8 @@ gem 'pry', '>= 0.12'
 gem 'rspec', '>= 3.8'
 gem 'rspec_junit_formatter', '>= 0.4'
 gem 'rubocop', '>= 1.0'
+gem 'rubocop-performance', '>= 1.5'
+gem 'rubocop-rspec'
 gem 'simplecov', '>= 0.16'
 
 gemspec

--- a/bc-prometheus-ruby.gemspec
+++ b/bc-prometheus-ruby.gemspec
@@ -31,7 +31,7 @@ Gem::Specification.new do |spec|
 
   spec.files         = Dir['README.md', 'CHANGELOG.md', 'CODE_OF_CONDUCT.md', 'lib/**/*', 'bc-prometheus-ruby.gemspec']
   spec.require_paths = ['lib']
-  spec.required_ruby_version = '>= 3.0'
+  spec.required_ruby_version = '>= 3.2'
 
   spec.add_runtime_dependency 'bigcommerce-multitrap', '~> 0.1'
   spec.add_runtime_dependency 'prometheus_exporter', '~> 0.7'

--- a/lib/bigcommerce/prometheus/version.rb
+++ b/lib/bigcommerce/prometheus/version.rb
@@ -17,6 +17,6 @@
 #
 module Bigcommerce
   module Prometheus
-    VERSION = '0.6.1.pre'
+    VERSION = '0.8.0.pre'
   end
 end


### PR DESCRIPTION
## What? Why?

* Add support for Ruby 3.4
* Drop support for Ruby 3.0, 3.1 (EOL)

## How was it tested?

Unit suite should pass.

