### PR TITLE
Make prometheus client respect the `enabled` setting

### DIFF
--- a/lib/bigcommerce/prometheus/client.rb
+++ b/lib/bigcommerce/prometheus/client.rb
@@ -70,6 +70,14 @@ module Bigcommerce
       end
 
       ##
+      # @param [String] str
+      def send(str)
+        return unless Bigcommerce::Prometheus.enabled
+
+        super
+      end
+
+      ##
       # Process the current queue and flush to the collector
       #
       def process_queue

--- a/spec/bigcommerce/prometheus/client_spec.rb
+++ b/spec/bigcommerce/prometheus/client_spec.rb
@@ -33,4 +33,26 @@ describe Bigcommerce::Prometheus::Client do
       expect(ref1).to eq ref2
     end
   end
+
+  describe '#send' do
+    context 'when prometheus is enabled' do
+      before do
+        allow(Bigcommerce::Prometheus).to receive(:enabled).and_return(true)
+      end
+
+      it 'sends a message to the Prometheus server' do
+        expect { client.send('test_message') }.to change(client.instance_variable_get(:@queue), :size).by 1
+      end
+    end
+
+    context 'when prometheus is disabled' do
+      before do
+        allow(Bigcommerce::Prometheus).to receive(:enabled).and_return(false)
+      end
+
+      it 'sends a message to the Prometheus server' do
+        expect { client.send('test_message') }.not_to change(client.instance_variable_get(:@queue), :size)
+      end
+    end
+  end
 end


### PR DESCRIPTION
## What? Why?
I want to turn Prometheus off while developing so that I don't have dozens of log messages about prometheus not being able to connect, etc. Other automatic collectors respect this setting, but direct sending of metrics does not. 

This updates direct sending of metrics to respect this setting.

Not sure if this is the best way to accomplish this. Please let me know.

## How was it tested?
Updated tests.
Updated and tested in another service.
