### PR TITLE
DAT-1735: Upgrading prometheus_exporter

### DIFF
--- a/lib/bigcommerce/prometheus/servers/puma/controllers/metrics_controller.rb
+++ b/lib/bigcommerce/prometheus/servers/puma/controllers/metrics_controller.rb
@@ -38,6 +38,8 @@ module Bigcommerce
               else
                 @response.write(collected_metrics)
               end
+
+              set_header('Content-Type', 'text/plain; charset=utf-8')
               @response
             end
 

--- a/spec/bigcommerce/prometheus/servers/puma/rack_app_spec.rb
+++ b/spec/bigcommerce/prometheus/servers/puma/rack_app_spec.rb
@@ -1,0 +1,50 @@
+# frozen_string_literal: true
+
+# Copyright (c) 2019-present, BigCommerce Pty. Ltd. All rights reserved
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated
+# documentation files (the "Software"), to deal in the Software without restriction, including without limitation the
+# rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit
+# persons to whom the Software is furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in all copies or substantial portions of the
+# Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE
+# WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+# COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR
+# OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+#
+require 'spec_helper'
+
+describe Bigcommerce::Prometheus::Servers::Puma::RackApp do
+  let(:collector) { instance_double(PrometheusExporter::Server::Collector) }
+  let(:server_metrics) { instance_double(Bigcommerce::Prometheus::Servers::Puma::ServerMetrics) }
+  let(:app) { described_class.new(collector: collector, logger: logger) }
+
+  before do
+    allow(collector).to receive(:prometheus_metrics_text).and_return('')
+    allow(server_metrics).to receive(:to_prometheus_text).and_return('')
+    allow(Bigcommerce::Prometheus::Servers::Puma::ServerMetrics).to receive(:new).and_return(server_metrics)
+  end
+
+  describe '#call' do
+    subject { app.call(env) }
+
+    context 'when requesting GET /metrics' do
+      let(:env) do
+        {
+          'REQUEST_METHOD' => 'GET',
+          'PATH_INFO' => '/metrics',
+          'QUERY_STRING' => '',
+          'rack.input' => StringIO.new
+        }
+      end
+
+      it 'returns content type of text/plain' do
+        _status, headers, _body = subject
+        expect(headers['Content-Type']).to eq('text/plain; charset=utf-8')
+      end
+    end
+  end
+end


### PR DESCRIPTION
## What? Why?

This PR adds a Content-Type header to work with newer versions of Prometheus.

This link describes the details of the Content-Type header settings
https://prometheus.io/docs/instrumenting/content_negotiation/


## How was it tested?

First I started with running two versions of Prometheus with the same scrape configuration:

docker-compose.yml
```
services:
  prometheus-old:
    image: prom/prometheus:v2.50.0
    volumes:
      - "./prometheus.yml:/etc/prometheus/prometheus.yml"
    ports:
      - 9090:9090
  prometheus-new:
    image: prom/prometheus
    volumes:
      - "./prometheus.yml:/etc/prometheus/prometheus.yml"
    ports:
      - 9091:9090
```

prometheus.yml
```
scrape_configs:
  - job_name: 'bc-prometheus-ruby'
    metrics_path: '/metrics'
    scrape_interval: 5s
    static_configs:
      - targets: ['host.docker.internal:9394']
```

Then i used the default code from the readme of this repository.

```
#!/usr/bin/env ruby

ENV['BUNDLE_GEMFILE'] ||= File.expand_path('Gemfile', __dir__)
require 'bundler/setup' # Set up gems listed in the Gemfile.

require 'bigcommerce/prometheus'

class AppTypeCollector < ::Bigcommerce::Prometheus::TypeCollectors::Base
  def build_metrics
    {
      honks: PrometheusExporter::Metric::Counter.new('honks', 'Running counter of honks'),
      points: PrometheusExporter::Metric::Gauge.new('points', 'Current amount of points')
    }
  end

  def collect_metrics(data:, labels: {})
    metric(:points).observe(data.fetch('points', 0))
    metric(:honks).observe(1, labels) if data.fetch('honks', 0).to_i.positive?
  end
end

class AppCollector < ::Bigcommerce::Prometheus::Collectors::Base
  def honk!
    push(
      honks: 1,
      custom_labels: {
        volume: 'loud'
      }
    )
  end

  def collect(metrics)
    metrics[:points] = rand(1..100)
    metrics
  end
end

::Bigcommerce::Prometheus.configure do |c|
  c.web_collectors = [AppCollector]
  c.web_type_collectors = [AppTypeCollector.new]
  c.resque_collectors = [AppCollector]
  c.resque_type_collectors = [AppTypeCollector.new]
  c.hutch_collectors = [AppCollector]
  c.hutch_type_collectors = [AppTypeCollector.new]
end

server = ::Bigcommerce::Prometheus::Server.new
Bigcommerce::Prometheus.web_type_collectors.each do |tc|
  server.add_type_collector(tc)
end

server.start_until_stopped do
  app_collector = AppCollector.new
  app_collector.honk!
  puts 'waiting'
end
```

Here are the metrics that are produced from the code above with the content-type being set

```
❯ curl -v localhost:9394/metrics
* Host localhost:9394 was resolved.
* IPv6: ::1
* IPv4: 127.0.0.1
*   Trying [::1]:9394...
* connect to ::1 port 9394 from ::1 port 51494 failed: Connection refused
*   Trying 127.0.0.1:9394...
* Connected to localhost (127.0.0.1) port 9394
> GET /metrics HTTP/1.1
> Host: localhost:9394
> User-Agent: curl/8.7.1
> Accept: */*
>
* Request completely sent off
< HTTP/1.1 200 OK
< content-type: text/plain; charset=utf-8
< content-length: 898
<
# HELP ruby_collector_metrics_total Total metrics processed by exporter.
# TYPE ruby_collector_metrics_total counter
ruby_collector_metrics_total 1


# HELP ruby_collector_sessions_total Total send_metric sessions processed by exporter.
# TYPE ruby_collector_sessions_total counter
ruby_collector_sessions_total 1


# HELP ruby_collector_bad_metrics_total Total mis-handled metrics by collector.
# TYPE ruby_collector_bad_metrics_total counter



# HELP ruby_collector_working Is the main process collector able to collect metrics
# TYPE ruby_collector_working gauge
ruby_collector_working 1


# HELP ruby_collector_rss total memory used by collector process
# TYPE ruby_collector_rss gauge
ruby_collector_rss 60512

# HELP ruby_honks Running counter of honks
# TYPE ruby_honks counter
ruby_honks{volume="loud"} 1

# HELP ruby_points Current amount of points
# TYPE ruby_points gauge
ruby_points 0
* Connection #0 to host localhost left intact
```

Testing Prometheus v2.50.0:
<img width="1668" height="515" alt="image" src="https://github.com/user-attachments/assets/de677e26-b09c-4064-9ffe-43bd980bcb2e" />


Testing Prometheus v3.10.0:

<img width="1668" height="515" alt="image" src="https://github.com/user-attachments/assets/c1bfd953-7ae4-4143-936b-a5265fc1982a" />




<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: only adds an explicit `Content-Type` header on the `/metrics` endpoint and a small spec to lock in the behavior; no changes to metric generation or request routing.
> 
> **Overview**
> Ensures the Puma `/metrics` endpoint always returns `Content-Type: text/plain; charset=utf-8`, improving compatibility with newer Prometheus content negotiation expectations.
> 
> Adds a focused Rack app spec asserting the header is present for `GET /metrics` responses.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 573fed5a3187dc52fea11ac7381bfccd9be22178. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->