### PR TITLE
PAYMENTS-11567 Resque latency metrics

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@ Changelog for the bc-prometheus-ruby gem.
 
 ### Pending Release
 
+- Add opt-in per-Resque-job histograms `resque_job_queue_latency_seconds` and `resque_job_perform_duration_seconds`, labelled by `job_class`.
+
 ## 0.8.1
 
 - Prometheus client respects the enabled setting

--- a/README.md
+++ b/README.md
@@ -43,6 +43,18 @@ require 'bigcommerce/prometheus'
 Bigcommerce::Prometheus::Instrumentors::Resque.new(app: Rails.application).start
 ```
 
+### Per-job metrics (opt-in)
+
+Set `PROMETHEUS_RESQUE_PER_JOB_METRICS_ENABLED=1` on Resque worker pods to enable two additional histograms recorded from the parent worker process.
+
+- `resque_job_queue_latency_seconds{job_class}` — time from `scheduled_at` (falling back to `enqueued_at`) until a worker picks the job up. Per attempt; retries-with-backoff anchor on `scheduled_at` so the intentional backoff doesn't show as latency.
+- `resque_job_perform_duration_seconds{job_class}` — total Resque child lifetime (fork → `Process.waitpid` return). Includes fork overhead, Redis reconnect, after_fork hooks, perform, and exit.
+
+These are off by default because they emit one histogram observation per job per worker pod, which adds cardinality. Opt in per service.
+
+`resque_job_queue_latency_seconds` is supported for jobs enqueued via ActiveJob (`.perform_later`) — the enqueue timestamps come from ActiveJob's serialized payload, and the `job_class` label is the user's job class name, not `ActiveJob::QueueAdapters::ResqueAdapter::JobWrapper`. 
+Vanilla Resque jobs (`Resque.enqueue`) carry no enqueue timestamps, so `queue_latency` silently no-ops for them; `perform_duration` works for every job regardless.
+
 ## Configuration
 
 After requiring the main file, you can further configure with:
@@ -58,6 +70,7 @@ After requiring the main file, you can further configure with:
 | server_thread_pool_size | The number of threads used for the exporter server | `3` | `ENV['PROMETHEUS_SERVER_THREAD_POOL_SIZE']` |
 | process_name | What the current process name is (used in logging) | `"unknown"` | `ENV['PROCESS']` |
 | railtie_disabled | Opt out flag for Railtie; use `Bigcommerce::Prometheus::Instrumentors::Web.new(app: Rails.application).start` in your app's code to start it up yourself  | `0` | `ENV['PROMETHEUS_DISABLE_RAILTIE']` |
+| resque_per_job_metrics_enabled | Enable per-job queue-latency and perform-duration histograms (parent-side, no synchronous flush) | `0` | `ENV['PROMETHEUS_RESQUE_PER_JOB_METRICS_ENABLED']` |
 
 ## Custom Collectors
 

--- a/lib/bigcommerce/prometheus.rb
+++ b/lib/bigcommerce/prometheus.rb
@@ -35,6 +35,7 @@ require_relative 'prometheus/collectors/base'
 require_relative 'prometheus/collectors/resque'
 require_relative 'prometheus/type_collectors/base'
 require_relative 'prometheus/type_collectors/resque'
+require_relative 'prometheus/type_collectors/resque_job'
 require_relative 'prometheus/integrations/active_record'
 require_relative 'prometheus/type_collectors/active_record'
 
@@ -44,6 +45,10 @@ require_relative 'prometheus/instrumentors/resque'
 require_relative 'prometheus/integrations/railtie' if defined?(Rails)
 require_relative 'prometheus/integrations/puma'
 require_relative 'prometheus/integrations/resque'
+require_relative 'prometheus/integrations/resque/active_job_payload'
+require_relative 'prometheus/integrations/resque/vanilla_resque_payload'
+require_relative 'prometheus/integrations/resque/job_payload'
+require_relative 'prometheus/integrations/resque/job_metrics'
 
 require_relative 'prometheus/servers/puma/server'
 require_relative 'prometheus/servers/puma/rack_app'

--- a/lib/bigcommerce/prometheus/configuration.rb
+++ b/lib/bigcommerce/prometheus/configuration.rb
@@ -35,6 +35,7 @@ module Bigcommerce
         puma_process_label: ENV.fetch('PROMETHEUS_PUMA_PROCESS_LABEL', 'web').to_s,
         resque_collection_frequency: ENV.fetch('PROMETHEUS_RESQUE_COLLECTION_FREQUENCY', 30).to_i,
         resque_process_label: ENV.fetch('PROMETHEUS_REQUEST_PROCESS_LABEL', 'resque').to_s,
+        resque_per_job_metrics_enabled: ENV.fetch('PROMETHEUS_RESQUE_PER_JOB_METRICS_ENABLED', 0).to_i.positive?,
 
         # Server configuration
         not_found_body: ENV.fetch('PROMETHEUS_SERVER_NOT_FOUND_BODY', 'Not Found! The Prometheus Ruby Exporter only listens on /metrics and /send-metrics').to_s,

--- a/lib/bigcommerce/prometheus/instrumentors/resque.rb
+++ b/lib/bigcommerce/prometheus/instrumentors/resque.rb
@@ -46,6 +46,7 @@ module Bigcommerce
 
           server.add_type_collector(PrometheusExporter::Server::ActiveRecordCollector.new)
           server.add_type_collector(Bigcommerce::Prometheus::TypeCollectors::Resque.new)
+          server.add_type_collector(Bigcommerce::Prometheus::TypeCollectors::ResqueJob.new)
           @type_collectors.each do |tc|
             server.add_type_collector(tc)
           end

--- a/lib/bigcommerce/prometheus/integrations/resque/active_job_payload.rb
+++ b/lib/bigcommerce/prometheus/integrations/resque/active_job_payload.rb
@@ -1,0 +1,65 @@
+# frozen_string_literal: true
+
+# Copyright (c) 2019-present, BigCommerce Pty. Ltd. All rights reserved
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated
+# documentation files (the "Software"), to deal in the Software without restriction, including without limitation the
+# rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit
+# persons to whom the Software is furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in all copies or substantial portions of the
+# Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE
+# WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+# COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR
+# OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+#
+require 'time'
+
+module Bigcommerce
+  module Prometheus
+    module Integrations
+      class Resque
+        ##
+        # Payload fields for an ActiveJob-shaped Resque job, read from the
+        # inner hash at `args[0]`. ActiveJob's JobWrapper stamps the three
+        # fields the per-job metrics consume:
+        #
+        #   * job_class    — the user's actual job class name; used as the
+        #                    metric label.
+        #   * enqueued_at  — ISO 8601 string; queue-latency anchor when
+        #                    scheduled_at is absent.
+        #   * scheduled_at — ISO 8601 string; preferred over enqueued_at
+        #                    when present (e.g. retries-with-backoff, so the
+        #                    intentional wait isn't counted as latency).
+        class ActiveJobPayload
+          # @return [String] the user's actual job class name
+          attr_reader :job_class
+
+          # @return [Time, nil] the queue-latency anchor; nil when both
+          #   timestamps are absent or unparseable
+          attr_reader :anchor_time
+
+          # @param [Hash] inner the ActiveJob-shaped hash at `args[0]`;
+          #   JobPayload.for guarantees a truthy 'job_class'
+          def initialize(inner)
+            @job_class   = inner['job_class']
+            @anchor_time = parse_time(inner['scheduled_at']) || parse_time(inner['enqueued_at'])
+          end
+
+          private
+
+          def parse_time(value)
+            return value if value.is_a?(Time)
+            return nil if value.nil? || value.to_s.empty?
+
+            Time.iso8601(value.to_s)
+          rescue ArgumentError
+            nil
+          end
+        end
+      end
+    end
+  end
+end

--- a/lib/bigcommerce/prometheus/integrations/resque/job_metrics.rb
+++ b/lib/bigcommerce/prometheus/integrations/resque/job_metrics.rb
@@ -1,0 +1,155 @@
+# frozen_string_literal: true
+
+# Copyright (c) 2019-present, BigCommerce Pty. Ltd. All rights reserved
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated
+# documentation files (the "Software"), to deal in the Software without restriction, including without limitation the
+# rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit
+# persons to whom the Software is furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in all copies or substantial portions of the
+# Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE
+# WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+# COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR
+# OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+#
+module Bigcommerce
+  module Prometheus
+    module Integrations
+      class Resque
+        ##
+        # Per-Resque-job histogram metrics, recorded from the parent worker process.
+        # Hooked via a prepend around Resque::Worker#perform_with_fork.
+        # Queue latency is captured before super, perform duration after.
+        #
+        # Off unless PROMETHEUS_RESQUE_PER_JOB_METRICS_ENABLED=1
+        # Emits one histogram observation per job per worker process, which can be high cardinality at scale.
+        #
+        # NOTE: queue_latency is supported for jobs enqueued via ActiveJob
+        # The gem reads three fields from
+        # `payload['args'][0]` (which must be a Hash):
+        #
+        #   * job_class    — the user's actual job class name; used as the
+        #                    metric label.
+        #   * enqueued_at  — ISO 8601 string; used as the queue-latency
+        #                    anchor when scheduled_at is absent.
+        #   * scheduled_at — ISO 8601 string; preferred over enqueued_at
+        #                    when present (e.g. retries-with-backoff, so
+        #                    the intentional wait isn't counted as latency).
+        #
+        # ActiveJob produces this shape natively — the payload is wrapped by
+        # ActiveJob::QueueAdapters::ResqueAdapter::JobWrapper, which stamps
+        # the three fields above into `args[0]`.
+        #
+        # Vanilla Resque jobs enqueued via Resque.enqueue carry no enqueue timestamps.
+        # class MyJob
+        #   @queue = :foo;
+        #   def self.perform;
+        # end
+        # Their args are raw primitive values, not a wrapping hash.
+        # For these jobs, queue_latency silently no-ops.
+        # perform_duration works for both styles regardless.
+        #
+        # Payloads that replicate the three fields above are read the same way.
+        # Detection is by shape, not by wrapper class name.
+        # This means a vanilla job can opt in to queue_latency either by
+        # - converting to ActiveJob
+        # - enqueueing through a small wrapper class that stamps these fields into args[0].
+        #
+        module JobMetrics
+          class << self
+            ##
+            # Install the parent-side hooks if the per-job metrics feature is enabled.
+            # Idempotent: safe to call multiple times.
+            #
+            # @param [PrometheusExporter::Client] client
+            #
+            def start(client:)
+              return unless ::Bigcommerce::Prometheus.resque_per_job_metrics_enabled
+
+              @client = client
+              install_hooks
+            end
+
+            ##
+            # Push the queue-latency observation for a job that's about to be picked up by a worker.
+            # Anchors on scheduled_at if present so retries-with-backoff don't show the intentional wait as latency.
+            # Falls back to enqueued_at if scheduled_at isn't present.
+            #
+            # @param [ActiveJobPayload, VanillaResquePayload] payload
+            #
+            def record_queue_latency(payload)
+              anchor = payload.anchor_time
+              return unless anchor
+
+              # Clock skew between the enqueuer/scheduler and the worker can put the anchor in the future.
+              # Clamp to zero so the histogram never records a negative latency.
+              latency = (Time.now - anchor).to_f.clamp(0.0..)
+
+              @client.send_json(
+                type: 'resque_job',
+                metric: 'queue_latency',
+                value: latency,
+                custom_labels: { job_class: payload.job_class }
+              )
+            rescue StandardError => e
+              ::Bigcommerce::Prometheus.logger&.warn(
+                "[bigcommerce-prometheus] resque_job queue_latency push failed: #{e.message}"
+              )
+            end
+
+            ##
+            # Push the perform-duration observation for a completed job.
+            # Called from the `Resque::Worker#perform_with_fork` prepend, so it measures the full child lifetime:
+            # fork + reconnect + perform + exit
+            #
+            # @param [ActiveJobPayload, VanillaResquePayload] payload
+            # @param [Float] duration in seconds
+            #
+            def record_perform_duration(payload, duration)
+              @client.send_json(
+                type: 'resque_job',
+                metric: 'perform_duration',
+                value: duration,
+                custom_labels: { job_class: payload.job_class }
+              )
+            rescue StandardError => e
+              ::Bigcommerce::Prometheus.logger&.warn(
+                "[bigcommerce-prometheus] resque_job perform_duration push failed: #{e.message}"
+              )
+            end
+
+            private
+
+            def install_hooks
+              return if @hooks_installed
+
+              ::Resque::Worker.prepend(WorkerInstrumentation)
+              @hooks_installed = true
+            end
+          end
+
+          ##
+          # Prepended onto Resque::Worker to capture for every job that goes through perform_with_fork:
+          # - queue latency: before super
+          # - perform duration: after super
+          module WorkerInstrumentation
+            def perform_with_fork(job, &block)
+              payload = JobPayload.for(job)
+              JobMetrics.record_queue_latency(payload)
+              started_at = Process.clock_gettime(Process::CLOCK_MONOTONIC)
+              super
+            ensure
+              JobMetrics.record_perform_duration(
+                payload,
+                Process.clock_gettime(Process::CLOCK_MONOTONIC) - started_at
+              )
+            end
+          end
+        end
+      end
+    end
+  end
+end

--- a/lib/bigcommerce/prometheus/integrations/resque/job_payload.rb
+++ b/lib/bigcommerce/prometheus/integrations/resque/job_payload.rb
@@ -1,0 +1,74 @@
+# frozen_string_literal: true
+
+# Copyright (c) 2019-present, BigCommerce Pty. Ltd. All rights reserved
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated
+# documentation files (the "Software"), to deal in the Software without restriction, including without limitation the
+# rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit
+# persons to whom the Software is furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in all copies or substantial portions of the
+# Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE
+# WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+# COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR
+# OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+#
+module Bigcommerce
+  module Prometheus
+    module Integrations
+      class Resque
+        ##
+        # Classifies a Resque::Job's payload and builds the matching
+        # shape-specific payload object for per-job metrics.
+        #
+        # A payload is ActiveJob-shaped when `args[0]` is a Hash carrying a
+        # truthy 'job_class' — the shape
+        # ActiveJob::QueueAdapters::ResqueAdapter::JobWrapper produces
+        # natively. Detection is by shape rather than by wrapper class name:
+        # the fields are ActiveJob's stable serialization format (persisted
+        # payloads must survive Rails upgrades), while the wrapper's class
+        # name is a private Rails constant — matching on it would silently
+        # kill the metric if Rails ever moved it. Payloads that replicate
+        # these fields are read the same way, by mechanism. Everything
+        # else — vanilla Resque jobs with primitive args, nil or non-Hash
+        # payloads, `args` not being an Array — is treated as vanilla.
+        #
+        # Both payload classes expose the same interface: #job_class
+        # (String) and #anchor_time (Time or nil).
+        #
+        module JobPayload
+          class << self
+            ##
+            # Never raises: instrumentation must not break job execution, so a payload object is always returned.
+            # Unexpected failures degrade to a vanilla payload labelled 'unknown'.
+            #
+            # @param [Resque::Job] resque_job
+            # @return [ActiveJobPayload, VanillaResquePayload]
+            #
+            def for(resque_job)
+              payload = resque_job.payload
+              payload = {} unless payload.is_a?(Hash)
+
+              inner = activejob_inner(payload)
+              inner ? ActiveJobPayload.new(inner) : VanillaResquePayload.new(payload)
+            rescue StandardError
+              VanillaResquePayload.new({})
+            end
+
+            private
+
+            def activejob_inner(payload)
+              args  = payload['args']
+              first = args.is_a?(Array) ? args.first : nil
+              return nil unless first.is_a?(Hash) && first['job_class']
+
+              first
+            end
+          end
+        end
+      end
+    end
+  end
+end

--- a/lib/bigcommerce/prometheus/integrations/resque/vanilla_resque_payload.rb
+++ b/lib/bigcommerce/prometheus/integrations/resque/vanilla_resque_payload.rb
@@ -18,25 +18,27 @@
 module Bigcommerce
   module Prometheus
     module Integrations
-      ##
-      # Plugin for resque
-      #
       class Resque
         ##
-        # Start the resque integration
+        # Payload fields for a vanilla Resque job.
+        # The top-level 'class' field is the real job class and the args are raw positional values.
+        # Vanilla payloads carry no enqueue timestamps, so there is never a queue-latency anchor.
+        # As such, queue_latency no-ops for these jobs by construction.
+        # perform_duration is unaffected.
         #
-        def self.start(client: nil)
-          ::PrometheusExporter::Instrumentation::Process.start(
-            client: client || ::Bigcommerce::Prometheus.client,
-            type: ::Bigcommerce::Prometheus.resque_process_label
-          )
-          ::Bigcommerce::Prometheus::Collectors::Resque.start(
-            client: client || ::Bigcommerce::Prometheus.client,
-            frequency: ::Bigcommerce::Prometheus.resque_collection_frequency
-          )
-          ::Bigcommerce::Prometheus::Integrations::Resque::JobMetrics.start(
-            client: client || ::Bigcommerce::Prometheus.client
-          )
+        class VanillaResquePayload
+          # @return [String] the top-level Resque payload class, or 'unknown' for malformed payloads
+          attr_reader :job_class
+
+          # @param [Hash] payload the raw Resque payload which is normalized to a Hash by JobPayload.for
+          def initialize(payload)
+            @job_class = payload['class'] || 'unknown'
+          end
+
+          # @return [nil] vanilla Resque payloads have no enqueue timestamps
+          def anchor_time
+            nil
+          end
         end
       end
     end

--- a/lib/bigcommerce/prometheus/type_collectors/resque_job.rb
+++ b/lib/bigcommerce/prometheus/type_collectors/resque_job.rb
@@ -1,0 +1,82 @@
+# frozen_string_literal: true
+
+# Copyright (c) 2019-present, BigCommerce Pty. Ltd. All rights reserved
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated
+# documentation files (the "Software"), to deal in the Software without restriction, including without limitation the
+# rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit
+# persons to whom the Software is furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in all copies or substantial portions of the
+# Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE
+# WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+# COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR
+# OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+#
+module Bigcommerce
+  module Prometheus
+    module TypeCollectors
+      ##
+      # Aggregates per-Resque-job histogram observations (`type: 'resque_job'`) pushed from worker processes by
+      # `Bigcommerce::Prometheus::Integrations::Resque::JobMetrics`.
+      #
+      class ResqueJob < Bigcommerce::Prometheus::TypeCollectors::Base
+        ##
+        # Override the auto-derived type so envelopes tagged `type: 'resque_job'` route to this collector via
+        # `PrometheusExporter::Server::Collector`.
+        #
+        def initialize(default_labels: {})
+          super(type: 'resque_job', default_labels: default_labels)
+        end
+
+        ##
+        # @return [Hash]
+        #
+        def build_metrics
+          {
+            queue_latency: build_queue_latency_histogram,
+            perform_duration: build_perform_duration_histogram
+          }
+        end
+
+        ##
+        # Observe the histogram for the named metric.
+        # Labels have already been merged with `custom_labels` by `TypeCollectors::Base#collect`.
+        #
+        def collect_metrics(data:, labels: {})
+          name = data['metric']
+          return unless %w[queue_latency perform_duration].include?(name)
+
+          metric(name.to_sym).observe(data['value'], labels)
+        end
+
+        private
+
+        def build_queue_latency_histogram
+          PrometheusExporter::Metric::Histogram.new(
+            'resque_job_queue_latency_seconds',
+            'Seconds between when a Resque job was due to run (scheduled_at if set, ' \
+            'falling back to enqueued_at) and when a worker process picked it up. ' \
+            'Recorded per attempt; retries-with-backoff anchor on scheduled_at, ' \
+            'excluding the intentional backoff wait. Opt-in via ' \
+            'PROMETHEUS_RESQUE_PER_JOB_METRICS_ENABLED.',
+            buckets: [0.01, 0.05, 0.1, 0.25, 0.5, 1, 2.5, 5, 30, 60, 120, 300]
+          )
+        end
+
+        def build_perform_duration_histogram
+          PrometheusExporter::Metric::Histogram.new(
+            'resque_job_perform_duration_seconds',
+            'Total Resque child process lifetime (fork to waitpid). Includes ' \
+            'fork overhead, Redis reconnect, after_fork hooks, perform, and ' \
+            'exit. Used as the per-job throughput signal at the worker-pod ' \
+            'level. Opt-in via PROMETHEUS_RESQUE_PER_JOB_METRICS_ENABLED.',
+            buckets: [0.05, 0.1, 0.25, 0.5, 1, 2, 5, 10, 30, 60]
+          )
+        end
+      end
+    end
+  end
+end

--- a/spec/bigcommerce/prometheus/integrations/resque/active_job_payload_spec.rb
+++ b/spec/bigcommerce/prometheus/integrations/resque/active_job_payload_spec.rb
@@ -1,0 +1,87 @@
+# frozen_string_literal: true
+
+# Copyright (c) 2019-present, BigCommerce Pty. Ltd. All rights reserved
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated
+# documentation files (the "Software"), to deal in the Software without restriction, including without limitation the
+# rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit
+# persons to whom the Software is furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in all copies or substantial portions of the
+# Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE
+# WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+# COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR
+# OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+#
+require 'spec_helper'
+
+describe Bigcommerce::Prometheus::Integrations::Resque::ActiveJobPayload do
+  # Mirrors the inner hash ActiveJob's JobWrapper stamps into args[0].
+  # JobPayload.for guarantees a truthy job_class before construction.
+  def inner_payload(job_class: 'MyJob', enqueued_at: nil, scheduled_at: nil)
+    {
+      'job_class' => job_class,
+      'arguments' => [],
+      'enqueued_at' => enqueued_at,
+      'scheduled_at' => scheduled_at
+    }.compact
+  end
+
+  describe '#job_class' do
+    it 'returns the inner job_class' do
+      expect(described_class.new(inner_payload(job_class: 'BigPay::SomePublishJob')).job_class)
+        .to eq('BigPay::SomePublishJob')
+    end
+  end
+
+  describe '#anchor_time' do
+    it 'prefers scheduled_at when both are present (excludes the intentional backoff)' do
+      enqueued = (Time.now - 30).iso8601(6)
+      scheduled = (Time.now - 1).iso8601(6)
+
+      anchor = described_class.new(inner_payload(enqueued_at: enqueued, scheduled_at: scheduled)).anchor_time
+
+      expect(anchor).to be_within(0.5).of(Time.now - 1)
+    end
+
+    it 'falls back to enqueued_at when scheduled_at is absent' do
+      enqueued = (Time.now - 3).iso8601(6)
+
+      anchor = described_class.new(inner_payload(enqueued_at: enqueued)).anchor_time
+
+      expect(anchor).to be_within(0.5).of(Time.now - 3)
+    end
+
+    it 'returns nil when neither timestamp is present' do
+      expect(described_class.new(inner_payload).anchor_time).to be_nil
+    end
+
+    it 'handles a Time instance directly in the payload' do
+      time = Time.now - 2
+
+      expect(described_class.new(inner_payload(enqueued_at: time)).anchor_time).to eq(time)
+    end
+
+    it 'returns nil for an unparseable string (no exception)' do
+      expect do
+        @anchor = described_class.new(inner_payload(enqueued_at: 'not a real time')).anchor_time
+      end.not_to raise_error
+      expect(@anchor).to be_nil
+    end
+
+    it 'returns nil for an empty string' do
+      expect(described_class.new(inner_payload(enqueued_at: '')).anchor_time).to be_nil
+    end
+  end
+
+  describe 'field independence under partial failure' do
+    it 'still returns job_class when the enqueued_at timestamp is unparseable' do
+      result = described_class.new(inner_payload(job_class: 'BigPay::SomeJob', enqueued_at: 'not a real time'))
+
+      expect(result.job_class).to eq('BigPay::SomeJob')
+      expect(result.anchor_time).to be_nil
+    end
+  end
+end

--- a/spec/bigcommerce/prometheus/integrations/resque/job_metrics_spec.rb
+++ b/spec/bigcommerce/prometheus/integrations/resque/job_metrics_spec.rb
@@ -1,0 +1,205 @@
+# frozen_string_literal: true
+
+# Copyright (c) 2019-present, BigCommerce Pty. Ltd. All rights reserved
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated
+# documentation files (the "Software"), to deal in the Software without restriction, including without limitation the
+# rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit
+# persons to whom the Software is furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in all copies or substantial portions of the
+# Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE
+# WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+# COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR
+# OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+#
+require 'spec_helper'
+
+# NOTE: this spec deliberately does not `require 'resque'`. Pulling Resque
+# into this gem's dev bundle conflicts with the gemspec's `rack >= 3.0`
+# requirement (Resque -> sinatra (old) -> rack < 3 under cold bundle
+# resolution). See the PR description for the testing-gap implications.
+#
+# The record_* examples test the pure logic in JobMetrics (anchor selection,
+# payload unwrapping, label assembly, error rescue) by injecting a client
+# directly via `instance_variable_set(:@client, ...)`. The `.start` examples
+# cover the env-var gating and the idempotent prepend against a stubbed
+# `Resque::Worker` via `stub_const`; behaviour against the real Resque::Worker
+# remains untested until Resque can be added to the dev bundle (blocked on
+# bumping the Sinatra dep — see follow-up).
+
+describe Bigcommerce::Prometheus::Integrations::Resque::JobMetrics do
+  let(:client) { instance_double(PrometheusExporter::Client, send_json: nil) }
+
+  before do
+    # Inject the client directly so each example exercises the record_* logic
+    # without the .start gating. The production code path is the same once
+    # `@client` is set.
+    described_class.instance_variable_set(:@client, client)
+  end
+
+  after do
+    described_class.instance_variable_set(:@client, nil)
+  end
+
+  # A minimal stand-in for Resque::Job — the production code only ever calls
+  # `.payload` on it, so a plain double is sufficient.
+  def resque_job_double(payload)
+    double('Resque::Job', payload: payload)
+  end
+
+  # Build a real payload object from a payload hash. Both record_* methods
+  # take the payload object the WorkerInstrumentation prepend builds once per
+  # job via JobPayload.for and shares between the two recordings;
+  # classification and parsing edge cases are covered in the payload specs.
+  def payload_for(payload_hash)
+    Bigcommerce::Prometheus::Integrations::Resque::JobPayload.for(resque_job_double(payload_hash))
+  end
+
+  def active_job_payload(job_class: 'MyJob', enqueued_at: nil, scheduled_at: nil)
+    {
+      'class' => 'ActiveJob::QueueAdapters::ResqueAdapter::JobWrapper',
+      'args' => [
+        {
+          'job_class' => job_class,
+          'arguments' => [],
+          'enqueued_at' => enqueued_at,
+          'scheduled_at' => scheduled_at
+        }.compact
+      ]
+    }
+  end
+
+  # Payload-shape edge cases (anchor selection, ActiveJob unwrapping, time
+  # parsing) are covered directly in job_payload_spec.rb. Tests here focus
+  # on JobMetrics's distinct responsibilities: envelope shape, gating,
+  # error rescue, and the JobMetrics → JobPayload integration.
+
+  describe '.record_queue_latency' do
+    it 'pushes the correct envelope for an ActiveJob-shaped payload' do
+      enqueued = (Time.now - 3).iso8601(6)
+
+      expect(client).to receive(:send_json).with(
+        type: 'resque_job',
+        metric: 'queue_latency',
+        value: a_value_within(0.5).of(3),
+        custom_labels: { job_class: 'MyJob' }
+      )
+
+      described_class.record_queue_latency(payload_for(active_job_payload(enqueued_at: enqueued)))
+    end
+
+    it 'clamps the value to zero when the anchor is in the future (clock skew)' do
+      future = (Time.now + 5).iso8601(6)
+
+      expect(client).to receive(:send_json).with(
+        hash_including(metric: 'queue_latency', value: 0.0)
+      )
+
+      described_class.record_queue_latency(payload_for(active_job_payload(enqueued_at: future)))
+    end
+
+    it 'is a no-op for a vanilla Resque payload (no anchor available, no exception)' do
+      payload = { 'class' => 'RawResqueJob', 'args' => [12_345, 'some_string'] }
+
+      expect(client).not_to receive(:send_json)
+
+      expect do
+        described_class.record_queue_latency(payload_for(payload))
+      end.not_to raise_error
+    end
+
+    context 'when client.send_json raises' do
+      it 'rescues the error and logs a warning' do
+        allow(client).to receive(:send_json).and_raise(StandardError, 'boom')
+        expect(Bigcommerce::Prometheus.logger).to receive(:warn).with(/queue_latency push failed: boom/)
+
+        expect do
+          described_class.record_queue_latency(
+            payload_for(active_job_payload(enqueued_at: Time.now.iso8601(6)))
+          )
+        end.not_to raise_error
+      end
+    end
+  end
+
+  describe '.record_perform_duration' do
+    it 'pushes the correct envelope for an ActiveJob-shaped payload' do
+      expect(client).to receive(:send_json).with(
+        type: 'resque_job',
+        metric: 'perform_duration',
+        value: 0.42,
+        custom_labels: { job_class: 'MyJob' }
+      )
+
+      described_class.record_perform_duration(payload_for(active_job_payload), 0.42)
+    end
+
+    it 'labels with the raw Resque payload class for vanilla Resque jobs' do
+      payload = { 'class' => 'RawResqueJob', 'args' => [12_345, 'some_string'] }
+
+      expect(client).to receive(:send_json).with(
+        hash_including(custom_labels: { job_class: 'RawResqueJob' })
+      )
+
+      described_class.record_perform_duration(payload_for(payload), 0.5)
+    end
+
+    context 'when client.send_json raises' do
+      it 'rescues the error and logs a warning' do
+        allow(client).to receive(:send_json).and_raise(StandardError, 'boom')
+        expect(Bigcommerce::Prometheus.logger).to receive(:warn).with(/perform_duration push failed: boom/)
+
+        expect do
+          described_class.record_perform_duration(payload_for(active_job_payload), 0.1)
+        end.not_to raise_error
+      end
+    end
+  end
+
+  describe '.start' do
+    let(:worker_class) { Class.new }
+
+    before do
+      stub_const('Resque::Worker', worker_class)
+      described_class.instance_variable_set(:@hooks_installed, nil)
+    end
+
+    after do
+      described_class.instance_variable_set(:@hooks_installed, nil)
+    end
+
+    context 'when the feature is disabled' do
+      it 'does not prepend the instrumentation' do
+        allow(Bigcommerce::Prometheus).to receive(:resque_per_job_metrics_enabled).and_return(false)
+
+        described_class.start(client: client)
+
+        expect(worker_class.ancestors).not_to include(described_class::WorkerInstrumentation)
+      end
+    end
+
+    context 'when the feature is enabled' do
+      before do
+        allow(Bigcommerce::Prometheus).to receive(:resque_per_job_metrics_enabled).and_return(true)
+      end
+
+      it 'prepends WorkerInstrumentation onto Resque::Worker' do
+        described_class.start(client: client)
+
+        expect(worker_class.ancestors).to include(described_class::WorkerInstrumentation)
+      end
+
+      it 'installs the hooks only once across repeated starts' do
+        allow(worker_class).to receive(:prepend).and_call_original
+
+        described_class.start(client: client)
+        described_class.start(client: client)
+
+        expect(worker_class).to have_received(:prepend).once
+      end
+    end
+  end
+end

--- a/spec/bigcommerce/prometheus/integrations/resque/job_payload_spec.rb
+++ b/spec/bigcommerce/prometheus/integrations/resque/job_payload_spec.rb
@@ -1,0 +1,124 @@
+# frozen_string_literal: true
+
+# Copyright (c) 2019-present, BigCommerce Pty. Ltd. All rights reserved
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated
+# documentation files (the "Software"), to deal in the Software without restriction, including without limitation the
+# rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit
+# persons to whom the Software is furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in all copies or substantial portions of the
+# Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE
+# WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+# COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR
+# OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+#
+require 'spec_helper'
+
+# Classification only: which payload class .for builds for each wire shape.
+# The field extraction behaviour of each class is covered in
+# active_job_payload_spec.rb and vanilla_resque_payload_spec.rb.
+
+describe Bigcommerce::Prometheus::Integrations::Resque::JobPayload do
+  def resque_job_double(payload)
+    double('Resque::Job', payload: payload)
+  end
+
+  def active_job_payload(job_class: 'MyJob', enqueued_at: nil, scheduled_at: nil)
+    {
+      'class' => 'ActiveJob::QueueAdapters::ResqueAdapter::JobWrapper',
+      'args' => [
+        {
+          'job_class' => job_class,
+          'arguments' => [],
+          'enqueued_at' => enqueued_at,
+          'scheduled_at' => scheduled_at
+        }.compact
+      ]
+    }
+  end
+
+  describe '.for' do
+    it 'builds an ActiveJobPayload for an ActiveJob-shaped payload' do
+      payload = described_class.for(resque_job_double(active_job_payload))
+
+      expect(payload).to be_a(Bigcommerce::Prometheus::Integrations::Resque::ActiveJobPayload)
+    end
+
+    it 'labels by the inner job_class, never the JobWrapper class' do
+      payload = described_class.for(resque_job_double(active_job_payload(job_class: 'BigPay::InnerJob')))
+
+      expect(payload.job_class).to eq('BigPay::InnerJob')
+    end
+
+    it 'builds a VanillaResquePayload for a vanilla payload (primitive args)' do
+      payload = described_class.for(
+        resque_job_double('class' => 'BigPay::EnablePpcpJob', 'args' => [12_345, 'some_string'])
+      )
+
+      expect(payload).to be_a(Bigcommerce::Prometheus::Integrations::Resque::VanillaResquePayload)
+    end
+
+    it 'builds a VanillaResquePayload when args is empty' do
+      payload = described_class.for(resque_job_double('class' => 'BigPay::EmptyJob', 'args' => []))
+
+      expect(payload).to be_a(Bigcommerce::Prometheus::Integrations::Resque::VanillaResquePayload)
+    end
+
+    it 'builds a VanillaResquePayload when args is missing' do
+      payload = described_class.for(resque_job_double('class' => 'BigPay::EmptyJob'))
+
+      expect(payload).to be_a(Bigcommerce::Prometheus::Integrations::Resque::VanillaResquePayload)
+    end
+
+    it 'builds a VanillaResquePayload when args is not an Array' do
+      payload = described_class.for(resque_job_double('class' => 'BigPay::WeirdJob', 'args' => 'not an array'))
+
+      expect(payload).to be_a(Bigcommerce::Prometheus::Integrations::Resque::VanillaResquePayload)
+    end
+
+    it 'builds a VanillaResquePayload when args[0] is a Hash without a job_class' do
+      payload = described_class.for(
+        resque_job_double('class' => 'BigPay::HashArgJob', 'args' => [{ 'enqueued_at' => Time.now.iso8601 }])
+      )
+
+      expect(payload).to be_a(Bigcommerce::Prometheus::Integrations::Resque::VanillaResquePayload)
+    end
+
+    it 'builds a VanillaResquePayload when the inner job_class is nil (no nil labels)' do
+      payload = described_class.for(
+        resque_job_double('class' => 'BigPay::HashArgJob', 'args' => [{ 'job_class' => nil }])
+      )
+
+      expect(payload).to be_a(Bigcommerce::Prometheus::Integrations::Resque::VanillaResquePayload)
+    end
+
+    it "builds a VanillaResquePayload when the job's payload is nil" do
+      payload = described_class.for(resque_job_double(nil))
+
+      expect(payload).to be_a(Bigcommerce::Prometheus::Integrations::Resque::VanillaResquePayload)
+    end
+
+    it 'builds a VanillaResquePayload when the payload is not a Hash' do
+      payload = described_class.for(resque_job_double('not a hash'))
+
+      expect(payload).to be_a(Bigcommerce::Prometheus::Integrations::Resque::VanillaResquePayload)
+    end
+
+    it "normalizes a non-Hash payload so the label falls back to 'unknown'" do
+      expect(described_class.for(resque_job_double(nil)).job_class).to eq('unknown')
+    end
+
+    it "returns a VanillaResquePayload labelled 'unknown' when payload access raises" do
+      job = double('Resque::Job')
+      allow(job).to receive(:payload).and_raise(StandardError, 'boom')
+
+      payload = described_class.for(job)
+
+      expect(payload).to be_a(Bigcommerce::Prometheus::Integrations::Resque::VanillaResquePayload)
+      expect(payload.job_class).to eq('unknown')
+    end
+  end
+end

--- a/spec/bigcommerce/prometheus/integrations/resque/vanilla_resque_payload_spec.rb
+++ b/spec/bigcommerce/prometheus/integrations/resque/vanilla_resque_payload_spec.rb
@@ -15,30 +15,28 @@
 # COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR
 # OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 #
-module Bigcommerce
-  module Prometheus
-    module Integrations
-      ##
-      # Plugin for resque
-      #
-      class Resque
-        ##
-        # Start the resque integration
-        #
-        def self.start(client: nil)
-          ::PrometheusExporter::Instrumentation::Process.start(
-            client: client || ::Bigcommerce::Prometheus.client,
-            type: ::Bigcommerce::Prometheus.resque_process_label
-          )
-          ::Bigcommerce::Prometheus::Collectors::Resque.start(
-            client: client || ::Bigcommerce::Prometheus.client,
-            frequency: ::Bigcommerce::Prometheus.resque_collection_frequency
-          )
-          ::Bigcommerce::Prometheus::Integrations::Resque::JobMetrics.start(
-            client: client || ::Bigcommerce::Prometheus.client
-          )
-        end
-      end
+require 'spec_helper'
+
+describe Bigcommerce::Prometheus::Integrations::Resque::VanillaResquePayload do
+  describe '#job_class' do
+    it 'returns the top-level Resque payload class' do
+      payload = described_class.new('class' => 'BigPay::EnablePpcpJob', 'args' => [12_345, 'some_string'])
+
+      expect(payload.job_class).to eq('BigPay::EnablePpcpJob')
+    end
+
+    it "returns 'unknown' when the class field is missing" do
+      expect(described_class.new('args' => []).job_class).to eq('unknown')
+    end
+
+    it "returns 'unknown' for an empty payload (factory-normalized nil or non-Hash)" do
+      expect(described_class.new({}).job_class).to eq('unknown')
+    end
+  end
+
+  describe '#anchor_time' do
+    it 'is always nil (vanilla payloads carry no enqueue timestamps)' do
+      expect(described_class.new('class' => 'BigPay::EnablePpcpJob').anchor_time).to be_nil
     end
   end
 end

--- a/spec/bigcommerce/prometheus/type_collectors/resque_job_spec.rb
+++ b/spec/bigcommerce/prometheus/type_collectors/resque_job_spec.rb
@@ -1,0 +1,136 @@
+# frozen_string_literal: true
+
+# Copyright (c) 2019-present, BigCommerce Pty. Ltd. All rights reserved
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated
+# documentation files (the "Software"), to deal in the Software without restriction, including without limitation the
+# rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit
+# persons to whom the Software is furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in all copies or substantial portions of the
+# Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE
+# WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+# COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR
+# OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+#
+require 'spec_helper'
+
+describe Bigcommerce::Prometheus::TypeCollectors::ResqueJob do
+  let(:type_collector) { described_class.new }
+
+  # The registered type is the production-routing contract:
+  # PrometheusExporter::Server::Collector keys @collectors by collector.type
+  # and dispatches each envelope by envelope['type']. JobMetrics.record_*
+  # hardcodes envelopes with type: 'resque_job', so this collector must
+  # register under the same string for the router to find it. Asserting it
+  # here keeps the contract from drifting silently (e.g. someone removing the
+  # explicit type: argument and falling back to the gsub auto-derivation).
+  describe '#type' do
+    it 'returns "resque_job" so the upstream router can dispatch resque_job envelopes' do
+      expect(type_collector.type).to eq('resque_job')
+    end
+  end
+
+  describe '#build_metrics' do
+    subject { type_collector.build_metrics }
+
+    it 'returns a hash of prometheus metric objects' do
+      expect(subject).to be_a(Hash)
+      expect(subject.count).to eq 2
+    end
+
+    {
+      queue_latency: {
+        name: 'resque_job_queue_latency_seconds',
+        class: PrometheusExporter::Metric::Histogram
+      },
+      perform_duration: {
+        name: 'resque_job_perform_duration_seconds',
+        class: PrometheusExporter::Metric::Histogram
+      }
+    }.each do |hash_key, config|
+      it "builds the #{hash_key} with the expected class and name" do
+        metric = subject[hash_key]
+        expect(metric).to be_a config[:class]
+        expect(metric.name).to eq config[:name]
+      end
+    end
+  end
+
+  # Exercise the public #collect entry point (defined on
+  # TypeCollectors::Base) so the spec catches any label-handling bugs in the
+  # Base → subclass dispatch — e.g. custom_labels getting merged twice.
+  describe '#collect' do
+    subject { type_collector.collect(data) }
+
+    let(:type_collector) { described_class.new(default_labels: default_labels) }
+    let(:default_labels) { { environment: 'development' } }
+
+    context 'with a queue_latency payload' do
+      let(:data) do
+        {
+          'type' => 'resque_job',
+          'metric' => 'queue_latency',
+          'value' => 1.5,
+          'custom_labels' => { 'job_class' => 'MyJob' }
+        }
+      end
+
+      # Base#collect merges data['custom_labels'] into labels once. The
+      # subclass must not re-merge — observing with the labels as-is is the
+      # correct behaviour. If a future refactor reintroduces a second merge,
+      # this assertion fails because the observed label hash would also
+      # include a duplicated/symbolised key.
+      it 'observes the queue_latency histogram with custom_labels merged exactly once' do
+        metrics = type_collector.instance_variable_get(:@metrics)
+
+        expect(metrics[:queue_latency]).to receive(:observe).with(1.5, default_labels.merge('job_class' => 'MyJob'))
+        expect(metrics[:perform_duration]).not_to receive(:observe)
+
+        subject
+      end
+    end
+
+    context 'with a perform_duration payload' do
+      let(:data) do
+        {
+          'type' => 'resque_job',
+          'metric' => 'perform_duration',
+          'value' => 0.25,
+          'custom_labels' => { 'job_class' => 'MyJob', 'event_name' => 'foo' }
+        }
+      end
+
+      it 'observes the perform_duration histogram with custom_labels merged exactly once' do
+        metrics = type_collector.instance_variable_get(:@metrics)
+
+        expect(metrics[:perform_duration]).to receive(:observe).with(0.25, default_labels.merge('job_class' => 'MyJob', 'event_name' => 'foo'))
+        expect(metrics[:queue_latency]).not_to receive(:observe)
+
+        subject
+      end
+    end
+
+    context 'with a payload with an unrecognised metric name' do
+      let(:data) do
+        {
+          'type' => 'resque_job',
+          'metric' => 'mystery',
+          'value' => 0.25,
+          'custom_labels' => {}
+        }
+      end
+
+      it 'is a no-op' do
+        metrics = type_collector.instance_variable_get(:@metrics)
+
+        expect(metrics[:queue_latency]).not_to receive(:observe)
+        expect(metrics[:perform_duration]).not_to receive(:observe)
+
+        subject
+      end
+    end
+  end
+end


### PR DESCRIPTION
## What? Why?
Adds opt-in latency metrics for Resque jobs.
- `resque_job_queue_latency_seconds{job_class}` : how long the job spent on the queue prior to being picked up for processing
- `resque_job_perform_duration_seconds{job_class}` : how long it takes to process the job

Off by default. Opt in per service by setting `PROMETHEUS_RESQUE_PER_JOB_METRICS_ENABLED=1`.

Supports both ActiveJob and vanilla Resque jobs. `resque_job_perform_duration_seconds` covers every job. `resque_job_queue_latency_seconds` is supported for ActiveJob-enqueued jobs only, because it reads fields from the ActiveJob payload — see below.

### The metrics introduced
#### resque_job_queue_latency_seconds
How long the job spent on the queue: time from `scheduled_at` (or `enqueued_at`) until the worker picks the job up.
Buckets: `[0.01, 0.05, 0.1, 0.25, 0.5, 1, 2.5, 5, 30, 60, 120, 300]`.
Latency is clamped to `0.0` minimum so that clock skew between the enqueuer and the worker host cannot produce a negative observation.

This metric relies on the job having the ActiveJob payload shape.
i.e. `payload['args'][0]` (a Hash) must contain
- `job_class` (string) — used as the metric label.
- `enqueued_at` (ISO 8601 string) — anchor when `scheduled_at` is absent.
- `scheduled_at` (ISO 8601 string, optional) — preferred anchor when present.

For vanilla Resque jobs without these fields, the metric silently no-ops for them.

Sample payloads for both shapes are in [Payload parsing](#payload-parsing) below.

The gem detects the payload by the fields above rather than by matching the `JobWrapper` class name so that non ActiveJob Resque tasks can also opt in by populating the necessary fields.

##### Converting vanilla jobs to support resque_job_queue_latency_seconds
Vanilla Resque jobs that need queue latency should be either
- converted to ActiveJob, or
- enqueued through a small wrapper class that produces the ActiveJob payload shape at enqueue time
Details for both routes are at the end of this doc: [Converting to ActiveJob](#converting-to-activejob) and [Wrapper class alternative](#wrapper-class-alternative).

##### Retries
ActiveJob re-stamps both `enqueued_at` and `scheduled_at` on every retry (including each re-queue).
This means that `resque_job_queue_latency_seconds` only reflects the latency for each individual retry.
To measure the entire duration from initial enqueue until dequeue of the final attempt, a separate userland metric is needed.
For example, domain events should have an `occurred_at` timestamp [as per the docs](https://docs.dev.bigcommerce.net/technical/standards/domain-eventing/specifications.html#encoding-specifications).
> `occurred_at` is populated with the time at which the event occurred, typically the current time

#### resque_job_perform_duration_seconds
How long does the processing of the job take.
This is the total child-process lifetime from fork to `Process.waitpid` return.
Buckets: `[0.05, 0.1, 0.25, 0.5, 1, 2, 5, 10, 30, 60]`.

This works for both vanilla Resque jobs and ActiveJobs and doesn't rely on any payload fields.

## Why this is implemented in bc-prometheus-ruby instead of each service
In-child metric collection requires a synchronous flush before `exit!` which is Resque's default child-exit.
The flush is bounded by the `bc-prometheus-ruby` worker thread's sleep cadence (0.5 s by default) — which makes it slow relative to fast publishes.
For example this metric was initially introduced in https://github.com/bigcommerce/bigpay/pull/10597 however had to be reverted as it increased Resque job run-time from 20ms to 500ms.
In contrast, the parent process is long-lived, so the bc-prom worker thread drains naturally between jobs without any synchronous wait.
Moving the instrumentation to the parent eliminates the per-job latency tax entirely.

This also ensures consistent metric names and labels.

## Opt-in env var
This is opt-in because per-job series can be high cardinality when a service has many Resque job classes.
This is enabled by `PROMETHEUS_RESQUE_PER_JOB_METRICS_ENABLED` (default `0`).
It is read once at boot via the existing `Bigcommerce::Prometheus.configure`. 
This mirrors the existing `PROMETHEUS_ENABLED` opt-in pattern.

## Implementation
`bc-prometheus-ruby` follows a producer/aggregator split.
Worker processes push metric observations as JSON envelopes to a long-running aggregator server, which accumulates them and exposes `/metrics` for Prometheus to scrape. 
The new per-job metrics follow the same pattern:
- a **producer** hook installed in the worker process captures queue latency and perform duration and pushes `type: 'resque_job'` envelopes.
- a new **aggregator** type collector (`TypeCollectors::ResqueJob`) on the server side receives those envelopes and records them into two Prometheus histograms.

### Producer — `Bigcommerce::Prometheus::Integrations::Resque::JobMetrics`
Records the metrics and pushes them to the aggregator.
#### Payload parsing

Resque payloads arrive in one of two shapes: ActiveJob-enqueued or vanilla.

An ActiveJob enqueued via `.perform_later` is stored with ActiveJob's `JobWrapper` as the Resque class, and the job's own details serialized into `args[0]`:

```json
{
  "class": "ActiveJob::QueueAdapters::ResqueAdapter::JobWrapper",
  "args": [
    {
      "job_class": "BigPay::SomePublishJob",
      "job_id": "07b08b09-8a1e-4f4d-9e0e-1f2a3b4c5d6e",
      "queue_name": "scheduled_action",
      "arguments": [12345],
      "enqueued_at": "2026-06-11T01:23:45.123456789Z",
      "scheduled_at": null
    }
  ]
}
```

A vanilla job enqueued via `Resque.enqueue(BigPay::Kount::ProcessNotificationJob, 12345)` is stored with its own class at the top level and raw positional args:

```json
{
  "class": "BigPay::Kount::ProcessNotificationJob",
  "args": [12345]
}
```

Payload parsing models each shape as its own DTO behind a common interface of `#job_class` and `#anchor_time`:

- `ActiveJobPayload` — built from the inner `args[0]` hash. From the first example: `job_class` is `"BigPay::SomePublishJob"`, and `anchor_time` parses from `scheduled_at`, falling back to `enqueued_at`.
- `VanillaResquePayload` — built from the whole payload. From the second example: `job_class` is `"BigPay::Kount::ProcessNotificationJob"`. `anchor_time` is always nil, because the payload carries no timestamps. Malformed payloads yield `'unknown'`.

`JobPayload.for(resque_job)` decides which to build, once per job. 
The criterion: a payload is ActiveJob-shaped when `args[0]` is a Hash carrying a truthy `job_class`; everything else is treated as vanilla. 
In the examples above, the first payload meets the criterion and the second does not.

Both DTOs eagerly extract everything in `initialize` and hold no reference to the `Resque::Job` afterwards. 
The recording methods take the prebuilt payload rather than reparsing the job on each call.

Consequences: `resque_job_perform_duration_seconds` emits a meaningful `job_class` label for vanilla Resque jobs too. 
However `resque_job_queue_latency_seconds` no-ops for vanilla Resque jobs, since there is no `#anchor_time`.

#### How the metrics are recorded

`WorkerInstrumentation` is a module prepended onto `Resque::Worker` that wraps `perform_with_fork`. 
It builds a payload object once per job via `JobPayload.for`, records queue latency before `super`, and records perform duration in `ensure`:

```ruby
def perform_with_fork(job, &block)
  started_at = Process.clock_gettime(Process::CLOCK_MONOTONIC)
  payload    = JobPayload.for(job)
  JobMetrics.record_queue_latency(payload)
  super
ensure
  JobMetrics.record_perform_duration(
    payload,
    Process.clock_gettime(Process::CLOCK_MONOTONIC) - started_at
  )
end
```

#### Class-method API

- `JobMetrics.start(client:)` — no-op unless the env var is on. Prepends `WorkerInstrumentation` onto `Resque::Worker`. Idempotent.
- `JobMetrics.record_queue_latency(payload)` — records how long the job sat on the queue: the seconds from the payload's `#anchor_time` to now. Feeds `resque_job_queue_latency_seconds`, labelled by the payload's `#job_class`. Does nothing when the payload has no anchor.
- `JobMetrics.record_perform_duration(payload, duration)` — records how long the job took to process; the caller measures and supplies the duration. Feeds `resque_job_perform_duration_seconds`, labelled by the payload's `#job_class`.

On the wire, each recording is sent to the aggregator with an envelope of `type: 'resque_job'`. 

Both `record_*` methods rescue `StandardError` and log a warning — metric push failures never propagate into the publish/perform path.

### Aggregator — type collectors

Everything above is the producer side, running in the worker process. The aggregator is the other half: the long-running server process that receives the pushed envelopes and exposes the accumulated metrics at `/metrics` for Prometheus to scrape.

Two type collectors, one per envelope shape, are registered side-by-side in `Instrumentors::Resque#start`. 
The upstream `PrometheusExporter::Server::Collector` routes each envelope to whichever collector's `type` matches `envelope['type']` — no in-collector dispatch needed.

- `Bigcommerce::Prometheus::TypeCollectors::Resque`: is the pre-existing aggregator and continues to own the aggregate worker/queue gauges (`resque_workers_total`, `jobs_failed_total`, `jobs_pending_total`, `jobs_processed_total`, `queues_total`, `queue_sizes`) fed by `Collectors::Resque#collect`.
- `Bigcommerce::Prometheus::TypeCollectors::ResqueJob`: the new aggregator owns the two new histograms:
    - `resque_job_queue_latency_seconds` with buckets tuned for queue dwell (`[0.01, 0.05, 0.1, 0.25, 0.5, 1, 2.5, 5, 30, 60, 120, 300]`).
    - `resque_job_perform_duration_seconds` with buckets tuned for per-job work (`[0.05, 0.1, 0.25, 0.5, 1, 2, 5, 10, 30, 60]`).


### Wiring

`Integrations::Resque.start(client:)` now also calls `JobMetrics.start(client:)`. 
If the env var is off, that call returns immediately and nothing is hooked. If on, the hooks install and the metrics flow.

`Integrations::Resque.start` is itself invoked inside a `Resque.before_first_fork` block (registered by `Instrumentors::Resque#setup_middleware`). 

## Converting to ActiveJob

Converting a vanilla job is mostly mechanical, with three things to plan for:
- In-flight old-shape payloads in Redis will fail against the converted class at deploy time. Drain the queue first, or keep a temporary `self.perform` shim.
- resque-scheduler YAML entries can't enqueue ActiveJobs natively. Each scheduled entry needs a small shim class.
- Arguments pass through ActiveJob serialization. ActiveRecord records become GlobalIDs.

## Wrapper class alternative

An alternative to converting a vanilla job to ActiveJob: a small service-local wrapper class that produces the ActiveJob payload shape at enqueue time.

The wrapper stamps the fields the gem reads into `args[0]` and delegates `perform` to the target job. The target job class is untouched. Callers opt in by enqueueing through the wrapper.

```ruby
class InstrumentedEnqueue
  def self.enqueue(job_class, *args)
    Resque.enqueue_to(
      Resque.queue_from_class(job_class),
      self,
      {
        'job_class' => job_class.name,
        'enqueued_at' => Time.now.utc.iso8601(9),
        'arguments' => args
      }
    )
  end

  def self.perform(payload)
    payload['job_class'].constantize.perform(*payload['arguments'])
  end
end

# the call site changes from
Resque.enqueue(BigPay::Kount::ProcessNotificationJob, 12345)
# to
InstrumentedEnqueue.enqueue(BigPay::Kount::ProcessNotificationJob, 12345)
```

This produces a payload that meets the classification criterion in [Payload parsing](#payload-parsing): `args[0]` is a Hash with a truthy `job_class`. `queue_latency` anchors on the stamped `enqueued_at`, and both metrics label with the target job's class name.

Trade-offs versus converting to ActiveJob:
- Per-call-site opt-in. Only enqueues that go through the wrapper get the metric. Un-migrated call sites coexist safely — their payloads simply skip the metric — so there is no deploy-ordering risk.
- The key names must match the gem's contract exactly: `job_class`, `enqueued_at`, `scheduled_at`.
- resque-scheduler YAML entries don't fit this pattern. Recurring scheduled jobs need a different approach.

## Testing
```
# HELP ruby_resque_job_queue_latency_seconds Seconds between when a Resque job was due to run (scheduled_at if set, falling back to enqueued_at) and when a worker process picked it up. Recorded per attempt; retries-with-backoff anchor on scheduled_at, excluding the intentional backoff wait. Opt-in via PROMETHEUS_RESQUE_PER_JOB_METRICS_ENABLED.
# TYPE ruby_resque_job_queue_latency_seconds histogram
ruby_resque_job_queue_latency_seconds_bucket{job_class="BigPay::DomainEventing::Payment::Webhook::PublishWebhookTransactionCreatedEventJob",le="+Inf"} 4
ruby_resque_job_queue_latency_seconds_bucket{job_class="BigPay::DomainEventing::Payment::Webhook::PublishWebhookTransactionCreatedEventJob",le="300"} 4
ruby_resque_job_queue_latency_seconds_bucket{job_class="BigPay::DomainEventing::Payment::Webhook::PublishWebhookTransactionCreatedEventJob",le="120"} 4
ruby_resque_job_queue_latency_seconds_bucket{job_class="BigPay::DomainEventing::Payment::Webhook::PublishWebhookTransactionCreatedEventJob",le="60"} 4
ruby_resque_job_queue_latency_seconds_bucket{job_class="BigPay::DomainEventing::Payment::Webhook::PublishWebhookTransactionCreatedEventJob",le="30"} 4
ruby_resque_job_queue_latency_seconds_bucket{job_class="BigPay::DomainEventing::Payment::Webhook::PublishWebhookTransactionCreatedEventJob",le="5"} 4
ruby_resque_job_queue_latency_seconds_bucket{job_class="BigPay::DomainEventing::Payment::Webhook::PublishWebhookTransactionCreatedEventJob",le="2.5"} 0
ruby_resque_job_queue_latency_seconds_bucket{job_class="BigPay::DomainEventing::Payment::Webhook::PublishWebhookTransactionCreatedEventJob",le="1"} 0
ruby_resque_job_queue_latency_seconds_bucket{job_class="BigPay::DomainEventing::Payment::Webhook::PublishWebhookTransactionCreatedEventJob",le="0.5"} 0
ruby_resque_job_queue_latency_seconds_bucket{job_class="BigPay::DomainEventing::Payment::Webhook::PublishWebhookTransactionCreatedEventJob",le="0.25"} 0
ruby_resque_job_queue_latency_seconds_bucket{job_class="BigPay::DomainEventing::Payment::Webhook::PublishWebhookTransactionCreatedEventJob",le="0.1"} 0
ruby_resque_job_queue_latency_seconds_bucket{job_class="BigPay::DomainEventing::Payment::Webhook::PublishWebhookTransactionCreatedEventJob",le="0.05"} 0
ruby_resque_job_queue_latency_seconds_bucket{job_class="BigPay::DomainEventing::Payment::Webhook::PublishWebhookTransactionCreatedEventJob",le="0.01"} 0
ruby_resque_job_queue_latency_seconds_count{job_class="BigPay::DomainEventing::Payment::Webhook::PublishWebhookTransactionCreatedEventJob"} 4
ruby_resque_job_queue_latency_seconds_sum{job_class="BigPay::DomainEventing::Payment::Webhook::PublishWebhookTransactionCreatedEventJob"} 17.02194
ruby_resque_job_queue_latency_seconds_bucket{job_class="BigPay::DomainEventing::Payment::Transaction::PublishUnstablePaymentTransactionCreatedEventJob",le="+Inf"} 2
ruby_resque_job_queue_latency_seconds_bucket{job_class="BigPay::DomainEventing::Payment::Transaction::PublishUnstablePaymentTransactionCreatedEventJob",le="300"} 2
ruby_resque_job_queue_latency_seconds_bucket{job_class="BigPay::DomainEventing::Payment::Transaction::PublishUnstablePaymentTransactionCreatedEventJob",le="120"} 2
ruby_resque_job_queue_latency_seconds_bucket{job_class="BigPay::DomainEventing::Payment::Transaction::PublishUnstablePaymentTransactionCreatedEventJob",le="60"} 2
ruby_resque_job_queue_latency_seconds_bucket{job_class="BigPay::DomainEventing::Payment::Transaction::PublishUnstablePaymentTransactionCreatedEventJob",le="30"} 2
ruby_resque_job_queue_latency_seconds_bucket{job_class="BigPay::DomainEventing::Payment::Transaction::PublishUnstablePaymentTransactionCreatedEventJob",le="5"} 2
ruby_resque_job_queue_latency_seconds_bucket{job_class="BigPay::DomainEventing::Payment::Transaction::PublishUnstablePaymentTransactionCreatedEventJob",le="2.5"} 0
ruby_resque_job_queue_latency_seconds_bucket{job_class="BigPay::DomainEventing::Payment::Transaction::PublishUnstablePaymentTransactionCreatedEventJob",le="1"} 0
ruby_resque_job_queue_latency_seconds_bucket{job_class="BigPay::DomainEventing::Payment::Transaction::PublishUnstablePaymentTransactionCreatedEventJob",le="0.5"} 0
ruby_resque_job_queue_latency_seconds_bucket{job_class="BigPay::DomainEventing::Payment::Transaction::PublishUnstablePaymentTransactionCreatedEventJob",le="0.25"} 0
ruby_resque_job_queue_latency_seconds_bucket{job_class="BigPay::DomainEventing::Payment::Transaction::PublishUnstablePaymentTransactionCreatedEventJob",le="0.1"} 0
ruby_resque_job_queue_latency_seconds_bucket{job_class="BigPay::DomainEventing::Payment::Transaction::PublishUnstablePaymentTransactionCreatedEventJob",le="0.05"} 0
ruby_resque_job_queue_latency_seconds_bucket{job_class="BigPay::DomainEventing::Payment::Transaction::PublishUnstablePaymentTransactionCreatedEventJob",le="0.01"} 0
ruby_resque_job_queue_latency_seconds_count{job_class="BigPay::DomainEventing::Payment::Transaction::PublishUnstablePaymentTransactionCreatedEventJob"} 2
ruby_resque_job_queue_latency_seconds_sum{job_class="BigPay::DomainEventing::Payment::Transaction::PublishUnstablePaymentTransactionCreatedEventJob"} 7.9414940000000005

# HELP ruby_resque_job_perform_duration_seconds Total Resque child process lifetime (fork to waitpid). Includes fork overhead, Redis reconnect, after_fork hooks, perform, and exit. Used as the per-job throughput signal at the worker-pod level. Opt-in via PROMETHEUS_RESQUE_PER_JOB_METRICS_ENABLED.
# TYPE ruby_resque_job_perform_duration_seconds histogram
ruby_resque_job_perform_duration_seconds_bucket{job_class="BigPay::DomainEventing::Payment::Webhook::PublishWebhookTransactionCreatedEventJob",le="+Inf"} 2
ruby_resque_job_perform_duration_seconds_bucket{job_class="BigPay::DomainEventing::Payment::Webhook::PublishWebhookTransactionCreatedEventJob",le="60"} 2
ruby_resque_job_perform_duration_seconds_bucket{job_class="BigPay::DomainEventing::Payment::Webhook::PublishWebhookTransactionCreatedEventJob",le="30"} 2
ruby_resque_job_perform_duration_seconds_bucket{job_class="BigPay::DomainEventing::Payment::Webhook::PublishWebhookTransactionCreatedEventJob",le="10"} 2
ruby_resque_job_perform_duration_seconds_bucket{job_class="BigPay::DomainEventing::Payment::Webhook::PublishWebhookTransactionCreatedEventJob",le="5"} 2
ruby_resque_job_perform_duration_seconds_bucket{job_class="BigPay::DomainEventing::Payment::Webhook::PublishWebhookTransactionCreatedEventJob",le="2"} 2
ruby_resque_job_perform_duration_seconds_bucket{job_class="BigPay::DomainEventing::Payment::Webhook::PublishWebhookTransactionCreatedEventJob",le="1"} 1
ruby_resque_job_perform_duration_seconds_bucket{job_class="BigPay::DomainEventing::Payment::Webhook::PublishWebhookTransactionCreatedEventJob",le="0.5"} 0
ruby_resque_job_perform_duration_seconds_bucket{job_class="BigPay::DomainEventing::Payment::Webhook::PublishWebhookTransactionCreatedEventJob",le="0.25"} 0
ruby_resque_job_perform_duration_seconds_bucket{job_class="BigPay::DomainEventing::Payment::Webhook::PublishWebhookTransactionCreatedEventJob",le="0.1"} 0
ruby_resque_job_perform_duration_seconds_bucket{job_class="BigPay::DomainEventing::Payment::Webhook::PublishWebhookTransactionCreatedEventJob",le="0.05"} 0
ruby_resque_job_perform_duration_seconds_count{job_class="BigPay::DomainEventing::Payment::Webhook::PublishWebhookTransactionCreatedEventJob"} 2
ruby_resque_job_perform_duration_seconds_sum{job_class="BigPay::DomainEventing::Payment::Webhook::PublishWebhookTransactionCreatedEventJob"} 2.5267620000522584
ruby_resque_job_perform_duration_seconds_bucket{job_class="BigPay::DomainEventing::Payment::Transaction::PublishUnstablePaymentTransactionCreatedEventJob",le="+Inf"} 2
ruby_resque_job_perform_duration_seconds_bucket{job_class="BigPay::DomainEventing::Payment::Transaction::PublishUnstablePaymentTransactionCreatedEventJob",le="60"} 2
ruby_resque_job_perform_duration_seconds_bucket{job_class="BigPay::DomainEventing::Payment::Transaction::PublishUnstablePaymentTransactionCreatedEventJob",le="30"} 2
ruby_resque_job_perform_duration_seconds_bucket{job_class="BigPay::DomainEventing::Payment::Transaction::PublishUnstablePaymentTransactionCreatedEventJob",le="10"} 2
ruby_resque_job_perform_duration_seconds_bucket{job_class="BigPay::DomainEventing::Payment::Transaction::PublishUnstablePaymentTransactionCreatedEventJob",le="5"} 2
ruby_resque_job_perform_duration_seconds_bucket{job_class="BigPay::DomainEventing::Payment::Transaction::PublishUnstablePaymentTransactionCreatedEventJob",le="2"} 2
ruby_resque_job_perform_duration_seconds_bucket{job_class="BigPay::DomainEventing::Payment::Transaction::PublishUnstablePaymentTransactionCreatedEventJob",le="1"} 2
ruby_resque_job_perform_duration_seconds_bucket{job_class="BigPay::DomainEventing::Payment::Transaction::PublishUnstablePaymentTransactionCreatedEventJob",le="0.5"} 0
ruby_resque_job_perform_duration_seconds_bucket{job_class="BigPay::DomainEventing::Payment::Transaction::PublishUnstablePaymentTransactionCreatedEventJob",le="0.25"} 0
ruby_resque_job_perform_duration_seconds_bucket{job_class="BigPay::DomainEventing::Payment::Transaction::PublishUnstablePaymentTransactionCreatedEventJob",le="0.1"} 0
ruby_resque_job_perform_duration_seconds_bucket{job_class="BigPay::DomainEventing::Payment::Transaction::PublishUnstablePaymentTransactionCreatedEventJob",le="0.05"} 0
ruby_resque_job_perform_duration_seconds_count{job_class="BigPay::DomainEventing::Payment::Transaction::PublishUnstablePaymentTransactionCreatedEventJob"} 2
ruby_resque_job_perform_duration_seconds_sum{job_class="BigPay::DomainEventing::Payment::Transaction::PublishUnstablePaymentTransactionCreatedEventJob"} 1.4121759999543428

```
