### PR TITLE
chore: drop Ruby 3.2 support, add Ruby 4.0 CI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -7,12 +7,6 @@ orbs:
 defaults: &defaults
   notify_failure: false
 
-ruby_3_2_defaults: &ruby_3_2_defaults
-  <<: *defaults
-  e:
-    name: ruby/ruby
-    ruby-version: '3.2'
-
 ruby_3_3_defaults: &ruby_3_3_defaults
   <<: *defaults
   e:
@@ -25,20 +19,14 @@ ruby_3_4_defaults: &ruby_3_4_defaults
     name: ruby/ruby
     ruby-version: '3.4'
 
+ruby_4_0_defaults: &ruby_4_0_defaults
+  <<: *defaults
+  e:
+    name: ruby/ruby
+    ruby-version: '4.0'
+
 workflows:
   version: 2
-  ruby_3_2:
-    jobs:
-      - ruby/bundle-audit:
-          <<: *ruby_3_2_defaults
-          name: ruby-3_2-bundle_audit
-      - ruby/rubocop:
-          <<: *ruby_3_2_defaults
-          name: ruby-3_2-rubocop
-      - ruby/rspec-unit:
-          <<: *ruby_3_2_defaults
-          name: ruby-3_2-rspec_unit
-          db: false
   ruby_3_3:
     jobs:
       - ruby/bundle-audit:
@@ -62,4 +50,16 @@ workflows:
       - ruby/rspec-unit:
           <<: *ruby_3_4_defaults
           name: ruby-3_4-rspec_unit
+          db: false
+  ruby_4_0:
+    jobs:
+      - ruby/bundle-audit:
+          <<: *ruby_4_0_defaults
+          name: ruby-4_0-bundle_audit
+      - ruby/rubocop:
+          <<: *ruby_4_0_defaults
+          name: ruby-4_0-rubocop
+      - ruby/rspec-unit:
+          <<: *ruby_4_0_defaults
+          name: ruby-4_0-rspec_unit
           db: false

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,5 +1,5 @@
 AllCops:
-  TargetRubyVersion: 3.2
+  TargetRubyVersion: 3.3
   Exclude:
     - spec/**/*
     - .bundle/**/*

--- a/bc-prometheus-ruby.gemspec
+++ b/bc-prometheus-ruby.gemspec
@@ -31,7 +31,7 @@ Gem::Specification.new do |spec|
 
   spec.files         = Dir['README.md', 'CHANGELOG.md', 'CODE_OF_CONDUCT.md', 'lib/**/*', 'bc-prometheus-ruby.gemspec']
   spec.require_paths = ['lib']
-  spec.required_ruby_version = '>= 3.2'
+  spec.required_ruby_version = '>= 3.3'
 
   spec.add_runtime_dependency 'bigcommerce-multitrap', '~> 0.1'
   spec.add_runtime_dependency 'prometheus_exporter', '~> 0.7'


### PR DESCRIPTION
## Summary
- Removes Ruby 3.2 workflow from CircleCI
- Adds Ruby 4.0 workflow to CircleCI (bundle-audit, rubocop, rspec-unit)
- Bumps `required_ruby_version` to `>= 3.3` in gemspec

## Test Plan
- [ ] CI passes on Ruby 3.3, 3.4, and 4.0

Refs: ENGP-429

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Tooling and declared minimum Ruby version only; no runtime library behavior changes in the diff.
> 
> **Overview**
> **Drops Ruby 3.2** from supported versions and **adds Ruby 4.0** to the CI matrix.
> 
> CircleCI no longer runs the `ruby_3_2` workflow (bundle-audit, rubocop, rspec-unit). A new `ruby_4_0` workflow mirrors the same jobs for Ruby 4.0. The gemspec now requires **`>= 3.3`**, and RuboCop’s **`TargetRubyVersion`** moves from 3.2 to **3.3**. CI for Ruby 3.3 and 3.4 is unchanged.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit cc514ec454466bc97a70372ff17a4ac5116a76b5. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->