### PR TITLE
INFRA-25589: fix(metrics) Add version=0.0.4 to Content-Type for Prometheus exposition format 0.0.4 compliance

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@ Changelog for the bc-prometheus-ruby gem.
 
 ## 0.8.2
 
-- Fix Prometheus 3.x Content-Type compliance: add `version=0.0.4` qualifier to the `text/plain` Content-Type header served by the Puma metrics controller (INFRA-25589)
+- Add `version=0.0.4` to `Content-Type` header for Prometheus exposition format 0.0.4 compliance (INFRA-25589)
 
 ## 0.8.1
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@ Changelog for the bc-prometheus-ruby gem.
 
 ## 0.8.2
 
-- Add `version=0.0.4` to `Content-Type` header for Prometheus exposition format 0.0.4 compliance (INFRA-25589)
+- Add `version=0.0.4` to `Content-Type` header for Prometheus exposition format 0.0.4 compliance
 
 ## 0.8.1
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@ Changelog for the bc-prometheus-ruby gem.
 
 ### Pending Release
 
+## 0.8.2
+
+- Fix Prometheus 3.x Content-Type compliance: add `version=0.0.4` qualifier to the `text/plain` Content-Type header served by the Puma metrics controller (INFRA-25589)
+
 ## 0.8.1
 
 - Prometheus client respects the enabled setting

--- a/lib/bigcommerce/prometheus/servers/puma/controllers/metrics_controller.rb
+++ b/lib/bigcommerce/prometheus/servers/puma/controllers/metrics_controller.rb
@@ -39,7 +39,7 @@ module Bigcommerce
                 @response.write(collected_metrics)
               end
 
-              set_header('Content-Type', 'text/plain; charset=utf-8')
+              set_header('Content-Type', 'text/plain; version=0.0.4; charset=utf-8')
               @response
             end
 

--- a/lib/bigcommerce/prometheus/version.rb
+++ b/lib/bigcommerce/prometheus/version.rb
@@ -17,6 +17,6 @@
 #
 module Bigcommerce
   module Prometheus
-    VERSION = '0.8.2.pre'
+    VERSION = '0.8.2'
   end
 end

--- a/spec/bigcommerce/prometheus/servers/puma/controllers/metrics_controller_spec.rb
+++ b/spec/bigcommerce/prometheus/servers/puma/controllers/metrics_controller_spec.rb
@@ -49,6 +49,10 @@ ruby_collector_metrics_total 19
 ruby_collector_sessions_total 19'
     end
 
+    it 'sets Prometheus text format 0.0.4 content type' do
+      expect(subject.headers['Content-Type']).to eq('text/plain; version=0.0.4; charset=utf-8')
+    end
+
     context 'when the metrics fail to parse' do
       let(:timeout_exception) { ::Timeout::Error }
       before do

--- a/spec/bigcommerce/prometheus/servers/puma/rack_app_spec.rb
+++ b/spec/bigcommerce/prometheus/servers/puma/rack_app_spec.rb
@@ -41,9 +41,9 @@ describe Bigcommerce::Prometheus::Servers::Puma::RackApp do
         }
       end
 
-      it 'returns content type of text/plain' do
+      it 'returns Prometheus text format 0.0.4 content type' do
         _status, headers, _body = subject
-        expect(headers['Content-Type']).to eq('text/plain; charset=utf-8')
+        expect(headers['Content-Type']).to eq('text/plain; version=0.0.4; charset=utf-8')
       end
     end
 


### PR DESCRIPTION
## What? Why?

Prometheus 3.x scraper rejects responses that don't include `version=0.0.4` in the `Content-Type` header — it returns `"no supported target format found"` and drops the scrape.

The Puma metrics controller was serving `text/plain; charset=utf-8`. This changes it to `text/plain; version=0.0.4; charset=utf-8` as required by the [Prometheus text exposition format 0.0.4 spec](https://prometheus.io/docs/instrumenting/exposition_formats/#text-based-format).

Bumps gem version to `0.8.2`.

INFRA-25589

## How was it tested?

- Updated `rack_app_spec` assertion to assert the correct `version=0.0.4` Content-Type header (was failing on CI)
- Added explicit Content-Type assertion in `metrics_controller_spec` (the controller is where the header is set)
- Full RSpec suite passes: 65 examples, 0 failures

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Single HTTP header change on the metrics endpoint with no change to metric body or auth; low blast radius aside from fixing broken scrapes.
> 
> **Overview**
> Updates the Puma **`GET /metrics`** response so scrapers (including Prometheus 3.x) accept the payload: **`Content-Type`** is now `text/plain; version=0.0.4; charset=utf-8` instead of omitting the format version.
> 
> Releases **0.8.2** (drops the `.pre` suffix) and documents the change in **CHANGELOG**. Specs for **`MetricsController`** and **`RackApp`** assert the new header.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e4f09518f197155049a39e87388d1414e6dac5e0. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->