### PR TITLE
chore(platform): PAYMENTS-11727 Release 0.8.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 Changelog for the bc-prometheus-ruby gem.
 
-### Pending Release
+## 0.8.3
 
 - Add opt-in per-Resque-job histograms `resque_job_queue_latency_seconds` and `resque_job_perform_duration_seconds`, labelled by `job_class`.
 

--- a/lib/bigcommerce/prometheus/version.rb
+++ b/lib/bigcommerce/prometheus/version.rb
@@ -17,6 +17,6 @@
 #
 module Bigcommerce
   module Prometheus
-    VERSION = '0.8.2'
+    VERSION = '0.8.3'
   end
 end


### PR DESCRIPTION
Finalizes the **0.8.3** release.

- Bump `version.rb` 0.8.2 → 0.8.3
- Move the per-Resque-job histograms entry (`resque_job_queue_latency_seconds`, `resque_job_perform_duration_seconds`) under a `## 0.8.3` changelog heading

**Why:** the `v0.8.3` tag and GitHub release were cut on the PR #31 merge commit without bumping the version, so `version.rb` still read `0.8.2`. The gemspec stamps the version from that constant, so nothing could ship as 0.8.3 (rubygems has nothing past 0.8.1).


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Release metadata only (version constant and changelog); no runtime or metric behavior changes in this diff.
> 
> **Overview**
> Aligns the published gem version with the **0.8.3** release after the tag was cut without a version bump.
> 
> **`lib/bigcommerce/prometheus/version.rb`** updates `Bigcommerce::Prometheus::VERSION` from `0.8.2` to `0.8.3` so the gemspec and RubyGems artifact match the intended release.
> 
> **`CHANGELOG.md`** replaces the `### Pending Release` section with `## 0.8.3`, keeping the existing note about opt-in Resque job histograms (`resque_job_queue_latency_seconds`, `resque_job_perform_duration_seconds`) under that version.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit daded7baf4e0530909c223a76edad8bfeda1f009. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->