### PR TITLE
PAYMENTS-11727 Proof: the fork delivery specs fail on the PAYMENTS-11567 flush approach

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -51,6 +51,22 @@ workflows:
           <<: *ruby_3_4_defaults
           name: ruby-3_4-rspec_unit
           db: false
+      # Forks real Resque children against a redis, so it is opt-in and excluded from the run above. The ruby executor
+      # already provides redis on localhost:6379, which is where the specs look by default.
+      #
+      # One ruby version is enough: what it exercises is fork and HTTP behaviour rather than anything version
+      # specific, and forking a few hundred children per version buys nothing. 3.4 matches the consuming service.
+      - ruby/rspec-unit:
+          <<: *ruby_3_4_defaults
+          name: ruby-3_4-rspec_fork_integration
+          db: false
+          code-climate: false
+          report-code-coverage: false
+          additional_args: "spec/integration"
+          pre-exec-hooks:
+            - run:
+                name: Enable the fork integration specs
+                command: echo 'export FORK_INTEGRATION=1' >> "$BASH_ENV"
   ruby_4_0:
     jobs:
       - ruby/bundle-audit:

--- a/Gemfile
+++ b/Gemfile
@@ -26,4 +26,13 @@ gem 'rubocop-performance', '>= 1.5'
 gem 'rubocop-rspec'
 gem 'simplecov', '>= 0.16'
 
+# Resque is an optional integration, but its fork-per-job lifecycle is the one thing the client has to survive, so the
+# integration needs real coverage rather than stubs.
+#
+# Resque depends on sinatra for its web UI with a loose `>= 0.9.2`. There is no Gemfile.lock in this repo, so CI
+# resolves cold and the resolver is free to pick an old sinatra that caps `rack < 3`, which conflicts with the
+# gemspec's `rack >= 3.0`. Pinning sinatra forward keeps the resolution rack-3 compatible.
+gem 'resque', '>= 2.0'
+gem 'sinatra', '>= 4.0'
+
 gemspec

--- a/lib/bigcommerce/prometheus.rb
+++ b/lib/bigcommerce/prometheus.rb
@@ -49,6 +49,7 @@ require_relative 'prometheus/integrations/resque/active_job_payload'
 require_relative 'prometheus/integrations/resque/vanilla_resque_payload'
 require_relative 'prometheus/integrations/resque/job_payload'
 require_relative 'prometheus/integrations/resque/job_metrics'
+require_relative 'prometheus/integrations/resque/child_flush'
 
 require_relative 'prometheus/servers/puma/server'
 require_relative 'prometheus/servers/puma/rack_app'

--- a/lib/bigcommerce/prometheus/integrations/resque/child_flush.rb
+++ b/lib/bigcommerce/prometheus/integrations/resque/child_flush.rb
@@ -18,35 +18,25 @@
 module Bigcommerce
   module Prometheus
     module Integrations
-      ##
-      # Plugin for resque
-      #
       class Resque
         ##
-        # Start the resque integration
+        # Deliver a forked child's observations before Resque tears it down, by waiting on the client's background
+        # drain thread.
         #
-        def self.start(client: nil)
-          install_child_flush
-          ::PrometheusExporter::Instrumentation::Process.start(
-            client: client || ::Bigcommerce::Prometheus.client,
-            type: ::Bigcommerce::Prometheus.resque_process_label
-          )
-          ::Bigcommerce::Prometheus::Collectors::Resque.start(
-            client: client || ::Bigcommerce::Prometheus.client,
-            frequency: ::Bigcommerce::Prometheus.resque_collection_frequency
-          )
-          ::Bigcommerce::Prometheus::Integrations::Resque::JobMetrics.start(
-            client: client || ::Bigcommerce::Prometheus.client
-          )
-        end
+        # This is not a proposal. It reconstructs the approach taken by bigpay PR #10597, which shipped and was
+        # reverted, so that the fork delivery specs can be run against it.
+        #
+        module ChildFlush
+          # bigpay passed 2 seconds. The value is an upper bound, not a cost: `stop` returns as soon as the queue is
+          # observed empty.
+          WAIT_TIMEOUT_SECONDS = 2
 
-        def self.install_child_flush
-          return if @child_flush_installed
-
-          ::Resque::Worker.prepend(ChildFlush)
-          @child_flush_installed = true
+          def perform(job, &block)
+            super
+          ensure
+            ::Bigcommerce::Prometheus.client.stop(wait_timeout_seconds: WAIT_TIMEOUT_SECONDS) if fork_per_job?
+          end
         end
-        private_class_method :install_child_flush
       end
     end
   end

--- a/spec/integration/resque_fork_delivery_spec.rb
+++ b/spec/integration/resque_fork_delivery_spec.rb
@@ -82,7 +82,8 @@ describe 'metric delivery from Resque forked children', :fork_integration do
     client = Bigcommerce::Prometheus.client
     client.instance_variable_set(:@host, '127.0.0.1')
     client.instance_variable_set(:@port, exporter.port)
-    client.reset_after_fork!
+    # 0.8.3 has no `reset_after_fork!`. Clearing the queue directly is the only part of it this setup needs.
+    client.instance_variable_get(:@queue).clear
 
     Bigcommerce::Prometheus::Integrations::Resque.start(client: client)
   end

--- a/spec/integration/resque_fork_delivery_spec.rb
+++ b/spec/integration/resque_fork_delivery_spec.rb
@@ -16,7 +16,6 @@
 # OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 #
 require 'spec_helper'
-require 'benchmark'
 require 'resque'
 
 ##
@@ -114,7 +113,13 @@ describe 'metric delivery from Resque forked children', :fork_integration do
   def run_jobs(count)
     count.times { Resque::Job.create(queue, ForkDeliveryProbeJob, 'n' => 1) }
     worker = Resque::Worker.new(queue)
-    Benchmark.realtime { count.times { worker.work_one_job } }
+
+    # Monotonic clock rather than Benchmark: benchmark stopped being a default gem in Ruby 4.0, and requiring it here
+    # would break every job in the suite, not just this one. RSpec loads all spec files before it applies tag filters,
+    # so a top-level require in an excluded file still runs.
+    started_at = Process.clock_gettime(Process::CLOCK_MONOTONIC)
+    count.times { worker.work_one_job }
+    Process.clock_gettime(Process::CLOCK_MONOTONIC) - started_at
   end
 
   # @return [Float] seconds of instrumentation cost per job

--- a/spec/integration/resque_fork_delivery_spec.rb
+++ b/spec/integration/resque_fork_delivery_spec.rb
@@ -1,0 +1,141 @@
+# frozen_string_literal: true
+
+# Copyright (c) 2019-present, BigCommerce Pty. Ltd. All rights reserved
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated
+# documentation files (the "Software"), to deal in the Software without restriction, including without limitation the
+# rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit
+# persons to whom the Software is furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in all copies or substantial portions of the
+# Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE
+# WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+# COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR
+# OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+#
+require 'spec_helper'
+require 'benchmark'
+require 'resque'
+
+##
+# Pushes a metric as the final statement of the job, with nothing after it.
+#
+# This is the worst case and the shape that broke in production: once the push returns there is no further work, so
+# Resque's `exit!` follows immediately and anything relying on the background delivery thread is lost.
+#
+class ForkDeliveryProbeJob
+  METRIC_NAME = 'fork_delivery_probe_counter'
+  @queue = :bc_prometheus_fork_delivery
+
+  def self.perform(_payload)
+    Bigcommerce::Prometheus.client.send_json(
+      type: 'fork_delivery_probe',
+      name: METRIC_NAME,
+      value: 1.0
+    )
+  end
+end
+
+##
+# Black box: N jobs run, N observations arrive, and instrumentation does not blow out job time.
+#
+# Deliberately says nothing about queues, threads or forks. Both properties have been broken by past changes from
+# opposite directions. PAYMENTS-11567 met completeness by adding 480ms per job. PAYMENTS-11727 kept job time flat by
+# silently dropping the metrics. A change that satisfies one at the expense of the other should fail here.
+#
+# Forks real children and needs a redis, so it is excluded from the default run. To run it:
+#
+#   FORK_INTEGRATION=1 REDIS_URL=redis://127.0.0.1:6379/15 bundle exec rspec spec/integration
+#
+describe 'metric delivery from Resque forked children', :fork_integration do
+  JOB_COUNT = 100
+
+  # Per-job overhead the instrumentation is allowed to add, measured against an identical run with metrics off so the
+  # machine's own speed cancels out.
+  #
+  # Measured cost is 0.90ms per job, against 2.5ms for the same jobs with metrics disabled, so the budget sits about
+  # 27x above what this should take and about 19x below the 480ms regression it exists to catch. Wide on both sides,
+  # because a latency assertion on CI hardware has to be.
+  OVERHEAD_BUDGET_SECONDS = 0.025
+
+  let(:exporter) { CountingExporter.new.start }
+  let(:queue) { ForkDeliveryProbeJob.instance_variable_get(:@queue) }
+
+  before do
+    skip "redis unavailable at #{redis_url}" unless redis_available?
+
+    Resque.redis = Redis.new(url: redis_url)
+    Resque.redis.redis.flushdb
+    Resque.logger = Logger.new(File::NULL)
+
+    Bigcommerce::Prometheus.configure do |config|
+      config.enabled = true
+      config.logger = Logger.new(File::NULL)
+      config.server_host = '127.0.0.1'
+      config.server_port = exporter.port
+    end
+
+    # The client is a singleton that captures host and port when it is first built, which earlier specs in the run may
+    # already have done. Point the existing instance at this run's exporter and drop anything they left queued, so the
+    # result does not depend on spec ordering.
+    client = Bigcommerce::Prometheus.client
+    client.instance_variable_set(:@host, '127.0.0.1')
+    client.instance_variable_set(:@port, exporter.port)
+    client.reset_after_fork!
+
+    Bigcommerce::Prometheus::Integrations::Resque.start(client: client)
+  end
+
+  after { exporter.stop }
+
+  describe 'completeness' do
+    it 'delivers one observation for every job that pushed one' do
+      run_jobs(JOB_COUNT)
+
+      expect(exporter.count_for(ForkDeliveryProbeJob::METRIC_NAME)).to eq JOB_COUNT
+    end
+  end
+
+  describe 'overhead' do
+    it 'adds less than the per-job budget over an identical run with metrics disabled' do
+      expect(measured_overhead_per_job).to be < OVERHEAD_BUDGET_SECONDS
+    end
+  end
+
+  # --- helpers -----------------------------------------------------------
+
+  # Drains the queue synchronously, one job at a time, so the run has no timers or sleeps in it. Each call still forks,
+  # runs the after_fork hooks and exits the child exactly as a live worker does.
+  #
+  # @param [Integer] count
+  # @return [Float] seconds elapsed
+  def run_jobs(count)
+    count.times { Resque::Job.create(queue, ForkDeliveryProbeJob, 'n' => 1) }
+    worker = Resque::Worker.new(queue)
+    Benchmark.realtime { count.times { worker.work_one_job } }
+  end
+
+  # @return [Float] seconds of instrumentation cost per job
+  def measured_overhead_per_job
+    Bigcommerce::Prometheus.enabled = false
+    without_metrics = run_jobs(JOB_COUNT)
+
+    Bigcommerce::Prometheus.enabled = true
+    with_metrics = run_jobs(JOB_COUNT)
+
+    (with_metrics - without_metrics) / JOB_COUNT
+  end
+
+  def redis_url
+    ENV.fetch('REDIS_URL', 'redis://127.0.0.1:6379/15')
+  end
+
+  def redis_available?
+    Redis.new(url: redis_url, timeout: 0.5).ping
+    true
+  rescue StandardError
+    false
+  end
+end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -26,4 +26,8 @@ RSpec.configure do |config|
     mocks.allow_message_expectations_on_nil = true
   end
   config.color = true
+
+  # Specs tagged :fork_integration fork real Resque children and need a redis, so they are opt-in rather than part of
+  # the default run. Enable with FORK_INTEGRATION=1.
+  config.filter_run_excluding(:fork_integration) unless ENV.fetch('FORK_INTEGRATION', nil)
 end

--- a/spec/support/counting_exporter.rb
+++ b/spec/support/counting_exporter.rb
@@ -1,0 +1,97 @@
+# frozen_string_literal: true
+
+# Copyright (c) 2019-present, BigCommerce Pty. Ltd. All rights reserved
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated
+# documentation files (the "Software"), to deal in the Software without restriction, including without limitation the
+# rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit
+# persons to whom the Software is furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in all copies or substantial portions of the
+# Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE
+# WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+# COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR
+# OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+#
+require 'json'
+require 'socket'
+
+##
+# Stands in for the exporter server and counts what arrives at /send-metrics.
+#
+# The fork-integration specs assert on how many observations actually crossed the process boundary, so they need a real
+# listener rather than a stubbed client. Counting envelopes here keeps those assertions independent of type collector
+# registration and of the exposition format.
+#
+class CountingExporter
+  # @return [Integer] the ephemeral port the exporter bound to
+  attr_reader :port
+
+  def initialize
+    @server = TCPServer.new('127.0.0.1', 0)
+    @port = @server.addr[1]
+    @envelopes = []
+    @mutex = Mutex.new
+  end
+
+  def start
+    @thread = Thread.new do
+      loop do
+        connection = @server.accept
+        Thread.new(connection) { |socket| serve(socket) }
+      end
+    end
+    self
+  end
+
+  def stop
+    @thread&.kill
+    begin
+      @server.close
+    rescue StandardError
+      nil
+    end
+  end
+
+  ##
+  # @param [String] name only count envelopes for this metric, ignoring anything the collectors also push
+  # @return [Integer]
+  #
+  def count_for(name)
+    @mutex.synchronize { @envelopes.count { |envelope| envelope['name'] == name } }
+  end
+
+  private
+
+  def serve(socket)
+    request_line = socket.gets
+    body = read_body(socket)
+    record(body) if request_line.to_s.include?('/send-metrics')
+    socket.write("HTTP/1.1 200 OK\r\nContent-Length: 2\r\nConnection: close\r\n\r\nOK")
+  rescue StandardError
+    nil
+  ensure
+    begin
+      socket.close
+    rescue StandardError
+      nil
+    end
+  end
+
+  def read_body(socket)
+    content_length = 0
+    while (line = socket.gets) && line != "\r\n"
+      content_length = line.split(':', 2).last.to_i if line.downcase.start_with?('content-length:')
+    end
+    content_length.positive? ? socket.read(content_length).to_s : ''
+  end
+
+  def record(body)
+    envelope = JSON.parse(body)
+    @mutex.synchronize { @envelopes << envelope }
+  rescue JSON::ParserError
+    nil
+  end
+end


### PR DESCRIPTION
Jira: [PAYMENTS-11727](https://bigcommercecloud.atlassian.net/browse/PAYMENTS-11727)

**Not for merge.** Companion to [#43](https://github.com/bigcommerce/bc-prometheus-ruby/pull/43). Together they show the
specs added in [#45](https://github.com/bigcommerce/bc-prometheus-ruby/pull/45) catch both prior regressions, one each.

## What? Why?

The PAYMENTS-11567 attempt at in-child metric collection shipped in
[bigpay#10597](https://github.com/bigcommerce/bigpay/pull/10597) and was reverted for raising Resque job time from 20ms
to 500ms. That code lived in bigpay, not here, so it cannot be cherry-picked. `849252b` reconstructs its one load-bearing
line instead: the child delivers by calling `client.stop(wait_timeout_seconds: 2)`, which waits on the background drain
thread rather than sending on the calling thread.

Everything else is #43's branch unchanged, so the specs are byte-identical between the two PRs.

The result is the mirror image of #43. **Completeness passes, overhead fails.** That is the PAYMENTS-11567 signature:
the observations did arrive, they were just unaffordable.

```
1) metric delivery from Resque forked children overhead adds less than the per-job budget over an identical run with metrics disabled
   Failure/Error: expect(measured_overhead_per_job).to be < OVERHEAD_BUDGET_SECONDS

     expected: < 0.025
          got:   0.05581208999967203

2 examples, 1 failure
```

## Reproducing the 480ms

56ms fails the budget but is an order of magnitude short of the figure recorded in production, so it is worth explaining
rather than leaving as an inconsistency. What the measurements show is a cliff, not a gradient.

Two mechanisms are in play and only one of them involves a sleep. `stop` polls `while @queue.length > 0` in 50ms steps.
The queue is emptied by a background thread whose loop is `drain, then sleep client_thread_sleep`, 0.5 seconds. So:

- If the queue is already empty by the time that thread first sleeps, `stop` returns having lost one 50ms poll.
- If anything is queued **after** that first drain, `stop` cannot return until the thread wakes. The child is pinned to
  the end of the sleep window.

Measured per job over 100 jobs, varying how many pushes the job makes and how much work separates them:

| pushes | gap between them | control | **total job time** | delta against control |
|---|---|---:|---:|---:|
| 1 | n/a          |   6.1 ms |  **61 ms** |  55 ms |
| 2 | none         |   4.0 ms |  **63 ms** |  59 ms |
| 2 | 0.05s        |  60.4 ms | **527 ms** | 466 ms |
| 2 | 0.20s        | 213.2 ms | **536 ms** | 322 ms |
| 2 | 0.30s        | 312.4 ms | **559 ms** | 246 ms |
| 2 | 0.45s        | 463.6 ms | **566 ms** | 103 ms |
| 3 | 0.05s        | 114.1 ms | **543 ms** | 429 ms |

Read the **total** column. It is constant at 527 to 566ms across every row in the second regime, whatever the job did in
between, and the 40ms spread is the 50ms poll granularity. The delta column declines only because it subtracts a control
run that performed the same gap, which hides whatever part of the wait overlapped the job's own work.

So the predicate is not how many metrics a job pushes, and not how long the job takes. It is whether any push lands after
the thread's first drain. Two pushes back to back cost 63ms; the same two pushes 50ms apart cost 527ms.

That is exactly the reported 20ms to 500ms. The bigpay job recorded queue latency on entry and publish duration after the
RabbitMQ round trip, so its second push always landed mid-sleep and it hit the ceiling on every job. A job pushing once
at the end would have paid 55ms and might never have been noticed.

The overhead example on this branch reports the 55ms row, because the probe job pushes once and returns. To see the
ceiling, apply this to the probe job. It is deliberately **not** committed, so that the specs stay identical to #45 and
#43:

```diff
   def self.perform(_payload)
-    Bigcommerce::Prometheus.client.send_json(
-      type: 'fork_delivery_probe',
-      name: METRIC_NAME,
-      value: 1.0
-    )
+    2.times do |index|
+      sleep(0.05) if index.positive?
+      Bigcommerce::Prometheus.client.send_json(
+        type: 'fork_delivery_probe',
+        name: METRIC_NAME,
+        value: 1.0
+      )
+    end
   end
```

## What this says about the fix

The shipped `flush!` drains on the calling thread, so neither mechanism applies: there is no cadence to wait on and no
poll to lose. 0.83ms against 527ms for the same feature. The difference between affordable and not was never in-child
collection itself, only which drain primitive the child called.

## How was it tested?

```bash
redis-server --port 6399 --save '' --appendonly no --daemonize yes
FORK_INTEGRATION=1 REDIS_URL=redis://127.0.0.1:6399/15 bundle exec rspec spec/integration
```

`ruby-3_4-rspec_fork_integration` is expected to be **red** on this branch, on the overhead example only.

[PAYMENTS-11727]: https://bigcommercecloud.atlassian.net/browse/PAYMENTS-11727?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

