### PR TITLE
PAYMENTS-12054 Fix the CI bundler cache and the puma spec port collisions

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -6,21 +6,25 @@ orbs:
 
 defaults: &defaults
   notify_failure: false
+  checksumfile: Gemfile
 
 ruby_3_3_defaults: &ruby_3_3_defaults
   <<: *defaults
+  cache_key: gem-cache-ruby-3_3
   e:
     name: ruby/ruby
     ruby-version: '3.3'
 
 ruby_3_4_defaults: &ruby_3_4_defaults
   <<: *defaults
+  cache_key: gem-cache-ruby-3_4
   e:
     name: ruby/ruby
     ruby-version: '3.4'
 
 ruby_4_0_defaults: &ruby_4_0_defaults
   <<: *defaults
+  cache_key: gem-cache-ruby-4_0
   e:
     name: ruby/ruby
     ruby-version: '4.0'

--- a/spec/bigcommerce/prometheus/servers/puma/server_spec.rb
+++ b/spec/bigcommerce/prometheus/servers/puma/server_spec.rb
@@ -1,12 +1,12 @@
 require 'spec_helper'
 
 describe Bigcommerce::Prometheus::Servers::Puma::Server do
-  let(:server) { @server = described_class.new(port: default_port) }
+  let(:server) { described_class.new(port: default_port) }
   let(:default_port) { 0 }
   before do
     Bigcommerce::Prometheus.reset
   end
-  after { @server&.binder&.close }
+  after { server.binder.close }
 
   context 'when the server is initialized' do
     it 'has a valid rack app' do

--- a/spec/bigcommerce/prometheus/servers/puma/server_spec.rb
+++ b/spec/bigcommerce/prometheus/servers/puma/server_spec.rb
@@ -1,12 +1,14 @@
 require 'spec_helper'
+require 'socket'
 
 describe Bigcommerce::Prometheus::Servers::Puma::Server do
-  let(:server) { described_class.new(port: default_port) }
+  let(:server) { described_class.new(port: default_port).tap { |s| started_servers << s } }
+  let(:started_servers) { [] }
   let(:default_port) { 0 }
   before do
     Bigcommerce::Prometheus.reset
   end
-  after { server.binder.close }
+  after { started_servers.each { |s| s.binder.close } }
 
   context 'when the server is initialized' do
     it 'has a valid rack app' do

--- a/spec/bigcommerce/prometheus/servers/puma/server_spec.rb
+++ b/spec/bigcommerce/prometheus/servers/puma/server_spec.rb
@@ -1,11 +1,12 @@
 require 'spec_helper'
 
 describe Bigcommerce::Prometheus::Servers::Puma::Server do
-  let(:server) { described_class.new(port: default_port) }
-  let(:default_port) { 9800 + rand(100) }
+  let(:server) { @server = described_class.new(port: default_port) }
+  let(:default_port) { 0 }
   before do
     Bigcommerce::Prometheus.reset
   end
+  after { @server&.binder&.close }
 
   context 'when the server is initialized' do
     it 'has a valid rack app' do

--- a/spec/bigcommerce/prometheus/servers/puma/server_spec.rb
+++ b/spec/bigcommerce/prometheus/servers/puma/server_spec.rb
@@ -38,7 +38,11 @@ describe Bigcommerce::Prometheus::Servers::Puma::Server do
   end
 
   context 'when the default port is configured' do
-    let(:server_port) { 9000 + rand(100) }
+    # Asks the kernel for a free port, then releases it so the server can claim it. Port 0 is not an option here,
+    # since the example asserts on the configured port.
+    let(:server_port) do
+      ::TCPServer.open(::Bigcommerce::Prometheus.server_host, 0) { |probe| probe.addr[1] }
+    end
     let(:default_port) { nil }
 
     before do


### PR DESCRIPTION
Jira: [PAYMENTS-12054](https://bigcommercecloud.atlassian.net/browse/PAYMENTS-12054)

N.B. no Changelog updates as will have a release with https://github.com/bigcommerce/bc-prometheus-ruby/pull/45
## What? Why?

Fixes

### 1. `restore_cache` has been failing on every job of every build

```
template: cacheKey:1:24: executing "cacheKey" at <checksum "Gemfile.lock">:
error calling checksum: open /home/circleci/repo/Gemfile.lock: no such file or directory
error computing cache key
```


[orbs/internal-ruby.yml](https://github.com/bigcommerce/circle-orbs/blob/ac3cdeb4cfab80691e0c3676bdecc1bc4b91d623/orbs/internal-ruby.yml#L321) builds its key as `<cache_key>-{{ arch }}-{{ checksum <checksumfile> }}`, and `checksumfile`
defaults to `Gemfile.lock`. 

This repo ships no lockfile, it is gitignored so it always resulted in a cache miss. 
The `Gemfile` is the stable file that does exist so it is used as the `checksumfile`.
Reduces the  build by ~ 5 mins.

### 2. The puma specs collide on ports
`default_port` was `9800 + rand(100)`
```ruby
require 'spec_helper'

describe Bigcommerce::Prometheus::Servers::Puma::Server do
  let(:server) { described_class.new(port: default_port) }
  let(:default_port) { 9800 + rand(100) }
  ```
Constructing the server binds a real listener. 
Three examples use it, so they collide about 3% of the time, raising an `Errno::EADDRINUSE`.


1.  **Bind ephemeral:** Port 0 asks the kernel for a free port so two live listeners cannot share one. 
2.  **Close on teardown:** closes the port on spec teardown.

## How was it tested?
CI

[PAYMENTS-12054]: https://bigcommercecloud.atlassian.net/browse/PAYMENTS-12054?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> CI and test-only changes with no production runtime behavior; low risk aside from verifying cache keys still isolate Ruby versions correctly.
> 
> **Overview**
> Fixes CircleCI **bundler cache restore** failures and **intermittent Puma server spec** port collisions.
> 
> **CI:** Sets shared `checksumfile: Gemfile` (this repo has no committed `Gemfile.lock`) and distinct `cache_key` values per Ruby job (`gem-cache-ruby-3_3`, `3_4`, `4_0`) so the internal-ruby orb can compute cache keys without error and restore gems reliably.
> 
> **Specs:** Puma `Server` examples now bind **port 0** for ephemeral listeners instead of `9800 + rand(100)`, track started servers, and **close binders in an `after` hook**. The configured-port example probes a free port via `TCPServer` on port 0 so assertions still target a known port without colliding with other examples.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 31bef9f25bdd3b2e090b6a47c4c1639182ef30f5. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->